### PR TITLE
Use `function.call` for empty arguments

### DIFF
--- a/dist/backburner.js-0.1.0.amd.js
+++ b/dist/backburner.js-0.1.0.amd.js
@@ -53,9 +53,12 @@ define("backburner",
           method = target[method];
         }
 
-        var args = arguments.length > 2 ? slice.call(arguments, 2) : [];
         try {
-          ret = method.apply(target, args);
+          if (arguments.length > 2) {
+            ret = method.apply(target, slice.call(arguments, 2));
+          } else {
+            ret = method.call(target);
+          }
         } finally {
           this.end();
         }
@@ -73,7 +76,7 @@ define("backburner",
         }
 
         var stack = new Error().stack,
-            args = arguments.length > 3 ? slice.call(arguments, 3) : [];
+            args = arguments.length > 3 ? slice.call(arguments, 3) : undefined;
         if (!this.currentInstance) { createAutorun(this); }
         return this.currentInstance.schedule(queueName, target, method, args, false, stack);
       },
@@ -89,7 +92,7 @@ define("backburner",
         }
 
         var stack = new Error().stack,
-            args = arguments.length > 3 ? slice.call(arguments, 3) : [];
+            args = arguments.length > 3 ? slice.call(arguments, 3) : undefined;
         if (!this.currentInstance) { createAutorun(this); }
         return this.currentInstance.schedule(queueName, target, method, args, true, stack);
       },
@@ -110,7 +113,18 @@ define("backburner",
           method = target[method];
         }
 
-        var args = arguments.length > 2 ? slice.call(arguments, 2) : [];
+        var fn, args;
+        if (arguments.length > 2) {
+          args = slice.call(arguments, 2);
+
+          fn = function() {
+            method.apply(target, args);
+          };
+        } else {
+          fn = function() {
+            method.call(target);
+          };
+        }
 
         // find position to insert - TODO: binary search
         var i, l;
@@ -118,9 +132,6 @@ define("backburner",
           if (executeAt < timers[i]) { break; }
         }
 
-        var fn = function() {
-          method.apply(target, args);
-        };
         timers.splice(i, 0, executeAt, fn);
 
         if (laterTimer && laterTimerExpiresAt < executeAt) { return fn; }
@@ -304,7 +315,11 @@ define("backburner/deferred_action_queues",
             if (typeof method === 'string') { method = target[method]; }
 
             // TODO: error handling
-            method.apply(target, args);
+            if (args && args.length > 0) {
+              method.apply(target, args);
+            } else {
+              method.call(target);
+            }
 
             queueIndex += 4;
           }

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -49,9 +49,12 @@ Backburner.prototype = {
       method = target[method];
     }
 
-    var args = arguments.length > 2 ? slice.call(arguments, 2) : [];
     try {
-      ret = method.apply(target, args);
+      if (arguments.length > 2) {
+        ret = method.apply(target, slice.call(arguments, 2));
+      } else {
+        ret = method.call(target);
+      }
     } finally {
       this.end();
     }
@@ -69,7 +72,7 @@ Backburner.prototype = {
     }
 
     var stack = new Error().stack,
-        args = arguments.length > 3 ? slice.call(arguments, 3) : [];
+        args = arguments.length > 3 ? slice.call(arguments, 3) : undefined;
     if (!this.currentInstance) { createAutorun(this); }
     return this.currentInstance.schedule(queueName, target, method, args, false, stack);
   },
@@ -85,7 +88,7 @@ Backburner.prototype = {
     }
 
     var stack = new Error().stack,
-        args = arguments.length > 3 ? slice.call(arguments, 3) : [];
+        args = arguments.length > 3 ? slice.call(arguments, 3) : undefined;
     if (!this.currentInstance) { createAutorun(this); }
     return this.currentInstance.schedule(queueName, target, method, args, true, stack);
   },
@@ -106,7 +109,18 @@ Backburner.prototype = {
       method = target[method];
     }
 
-    var args = arguments.length > 2 ? slice.call(arguments, 2) : [];
+    var fn, args;
+    if (arguments.length > 2) {
+      args = slice.call(arguments, 2);
+
+      fn = function() {
+        method.apply(target, args);
+      };
+    } else {
+      fn = function() {
+        method.call(target);
+      };
+    }
 
     // find position to insert - TODO: binary search
     var i, l;
@@ -114,9 +128,6 @@ Backburner.prototype = {
       if (executeAt < timers[i]) { break; }
     }
 
-    var fn = function() {
-      method.apply(target, args);
-    };
     timers.splice(i, 0, executeAt, fn);
 
     if (laterTimer && laterTimerExpiresAt < executeAt) { return fn; }

--- a/lib/backburner/deferred_action_queues.js
+++ b/lib/backburner/deferred_action_queues.js
@@ -56,7 +56,11 @@ DeferredActionQueues.prototype = {
         if (typeof method === 'string') { method = target[method]; }
 
         // TODO: error handling
-        method.apply(target, args);
+        if (args && args.length > 0) {
+          method.apply(target, args);
+        } else {
+          method.call(target);
+        }
 
         queueIndex += 4;
       }


### PR DESCRIPTION
I used `call` for performance.
It is 10 ~ 20% faster than using `apply` in all browsers I tried.

benchmark is here: http://jsfiddle.net/tricknotes/sWsqd/10/
