### PR TITLE
Fix to release `laterTimer` and `laterTimerExpiresAt`

### DIFF
--- a/dist/backburner.js-0.1.0.amd.js
+++ b/dist/backburner.js-0.1.0.amd.js
@@ -255,6 +255,8 @@ define("backburner",
       if (timers.length) {
         laterTimer = setTimeout(function() {
           executeTimers(self);
+          laterTimer = null;
+          laterTimerExpiresAt = null;
         }, timers[0] - now);
         laterTimerExpiresAt = timers[0];
       }

--- a/dist/backburner.js-0.1.0.js
+++ b/dist/backburner.js-0.1.0.js
@@ -292,6 +292,8 @@ define("backburner",
       if (timers.length) {
         laterTimer = setTimeout(function() {
           executeTimers(self);
+          laterTimer = null;
+          laterTimerExpiresAt = null;
         }, timers[0] - now);
         laterTimerExpiresAt = timers[0];
       }

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -251,6 +251,8 @@ function executeTimers(self) {
   if (timers.length) {
     laterTimer = setTimeout(function() {
       executeTimers(self);
+      laterTimer = null;
+      laterTimerExpiresAt = null;
     }, timers[0] - now);
     laterTimerExpiresAt = timers[0];
   }


### PR DESCRIPTION
The test for `setTimeout` is often gone away.
This cause is that `laterTimer` is left but tiemr is not schedueld.

In my local FireFox 20.0, this test couldn't finish at a rate of 20 ~ 30. 
