### PR TITLE
Make default queue configurable and create one if none is provided

### DIFF
--- a/dist/backburner.js-0.1.0.amd.js
+++ b/dist/backburner.js-0.1.0.amd.js
@@ -13,6 +13,9 @@ define("backburner",
     function Backburner(queueNames, options) {
       this.queueNames = queueNames;
       this.options = options || {};
+      if (!this.options.defaultQueue) {
+        this.options.defaultQueue = queueNames[0];
+      }
       this.instanceStack = [];
     }
 
@@ -248,7 +251,7 @@ define("backburner",
         fns = timers.splice(0, i);
 
         for (i = 1, l = fns.length; i < l; i += 2) {
-          self.schedule(self.queueNames[0], null, fns[i]); // TODO: make default queue configurable
+          self.schedule(self.options.defaultQueue, null, fns[i]);
         }
       });
 

--- a/dist/backburner.js-0.1.0.js
+++ b/dist/backburner.js-0.1.0.js
@@ -50,6 +50,9 @@ define("backburner",
     function Backburner(queueNames, options) {
       this.queueNames = queueNames;
       this.options = options || {};
+      if (!this.options.defaultQueue) {
+        this.options.defaultQueue = queueNames[0];
+      }
       this.instanceStack = [];
     }
 
@@ -285,7 +288,7 @@ define("backburner",
         fns = timers.splice(0, i);
 
         for (i = 1, l = fns.length; i < l; i += 2) {
-          self.schedule(self.queueNames[0], null, fns[i]); // TODO: make default queue configurable
+          self.schedule(self.options.defaultQueue, null, fns[i]);
         }
       });
 

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -9,6 +9,9 @@ var slice = [].slice,
 function Backburner(queueNames, options) {
   this.queueNames = queueNames;
   this.options = options || {};
+  if (!this.options.defaultQueue) {
+    this.options.defaultQueue = queueNames[0];
+  }
   this.instanceStack = [];
 }
 
@@ -244,7 +247,7 @@ function executeTimers(self) {
     fns = timers.splice(0, i);
 
     for (i = 1, l = fns.length; i < l; i += 2) {
-      self.schedule(self.queueNames[0], null, fns[i]); // TODO: make default queue configurable
+      self.schedule(self.options.defaultQueue, null, fns[i]);
     }
   });
 

--- a/test/tests/backburner_test.js
+++ b/test/tests/backburner_test.js
@@ -477,3 +477,16 @@ test("Queue#flush should be recursive if new items are added", function() {
   });
 
 });
+
+test("Default queue is automatically set to first queue if none is provided", function() {
+  var bb = new Backburner(['one', 'two']);
+  equal(bb.options.defaultQueue, 'one');
+});
+
+test("Default queue can be manually configured", function() {
+  var bb = new Backburner(['one', 'two'], {
+    defaultQueue: 'two'
+  });
+
+  equal(bb.options.defaultQueue, 'two');
+});


### PR DESCRIPTION
This makes the default queue used by timers configurable.  If no default queue is provided, create a new queue and set it as default.

This issue is blocking ember integration, because as it currently is, it uses the first queue in the array, which in Ember's case, is `sync`.

Using `sync` queue for timers defers observer firing because of `Ember.beginPropertyChanges` which is called before the `sync` queue is flushed.  

This causes issues which mainly show when setting a model property inside an `Em.run.next` or `Em.run.later`, the following jsbin displays the problem:  http://jsbin.com/ovefor/8/edit

Here's a fiddle showing how the problem is solved when a separate default queue is created (which is what my PR does): http://jsbin.com/ovefor/10/edit
