### PR TITLE
Fix `Function#apply`

### DIFF
--- a/dist/backburner.js-0.1.0.amd.js
+++ b/dist/backburner.js-0.1.0.amd.js
@@ -418,7 +418,12 @@ define("backburner/queue",
           method = queue[i+1];
           args   = queue[i+2];
 
-          method.apply(target, args); // TODO: error handling
+          // TODO: error handling
+          if (args && args.length > 0) {
+            method.apply(target, args);
+          } else {
+            method.call(target);
+          }
         }
         if (l && after) { after(); }
 

--- a/dist/backburner.js-0.1.0.js
+++ b/dist/backburner.js-0.1.0.js
@@ -455,7 +455,12 @@ define("backburner/queue",
           method = queue[i+1];
           args   = queue[i+2];
 
-          method.apply(target, args); // TODO: error handling
+          // TODO: error handling
+          if (args && args.length > 0) {
+            method.apply(target, args);
+          } else {
+            method.call(target);
+          }
         }
         if (l && after) { after(); }
 

--- a/lib/backburner/queue.js
+++ b/lib/backburner/queue.js
@@ -49,7 +49,12 @@ Queue.prototype = {
       method = queue[i+1];
       args   = queue[i+2];
 
-      method.apply(target, args); // TODO: error handling
+      // TODO: error handling
+      if (args && args.length > 0) {
+        method.apply(target, args);
+      } else {
+        method.call(target);
+      }
     }
     if (l && after) { after(); }
 


### PR DESCRIPTION
IE8 doesn't work with `undefined` as an arguments.
This fix is the same as 563a995bf07.

This patch fixes about 900 failed tests in Ember.js on IE8.
