### PR TITLE
Add beforeLoop and afterLoop callbacks

### DIFF
--- a/dist/backburner.js-0.1.0.amd.js
+++ b/dist/backburner.js-0.1.0.amd.js
@@ -26,21 +26,36 @@ define("backburner",
       instanceStack: null,
 
       begin: function() {
-        if (this.currentInstance) {
-          this.instanceStack.push(this.currentInstance);
+        var onBegin = this.options && this.options.onBegin,
+            previousInstance = this.currentInstance;
+
+        if (previousInstance) {
+          this.instanceStack.push(previousInstance);
         }
 
         this.currentInstance = new DeferredActionQueues(this.queueNames, this.options);
+        if (onBegin) {
+          onBegin(this.currentInstance, previousInstance);
+        }
       },
 
       end: function() {
+        var onEnd = this.options && this.options.onEnd,
+            currentInstance = this.currentInstance,
+            nextInstance = null;
+
         try {
-          this.currentInstance.flush();
+          currentInstance.flush();
         } finally {
           this.currentInstance = null;
 
           if (this.instanceStack.length) {
-            this.currentInstance = this.instanceStack.pop();
+            nextInstance = this.instanceStack.pop();
+            this.currentInstance = nextInstance;
+          }
+
+          if (onEnd) {
+            onEnd(currentInstance, nextInstance);
           }
         }
       },
@@ -319,7 +334,7 @@ define("backburner/deferred_action_queues",
           var options = queue.options,
               before = options && options.before,
               after = options && options.after,
-              target, method, args,
+              target, method, args, stack,
               queueIndex = 0, numberOfQueueItems = queueItems.length;
 
           if (numberOfQueueItems && before) { before(); }
@@ -327,6 +342,7 @@ define("backburner/deferred_action_queues",
             target = queueItems[queueIndex];
             method = queueItems[queueIndex+1];
             args   = queueItems[queueIndex+2];
+            stack  = queueItems[queueIndex+3]; // Debugging assistance
 
             if (typeof method === 'string') { method = target[method]; }
 
@@ -413,13 +429,14 @@ define("backburner/queue",
             options = this.options,
             before = options && options.before,
             after = options && options.after,
-            action, target, method, args, i, l = queue.length;
+            action, target, method, args, stack, i, l = queue.length;
 
         if (l && before) { before(); }
         for (i = 0; i < l; i += 4) {
           target = queue[i];
           method = queue[i+1];
           args   = queue[i+2];
+          stack  = queue[i+3]; // Debugging assistance
 
           // TODO: error handling
           if (args && args.length > 0) {

--- a/dist/backburner.js-0.1.0.js
+++ b/dist/backburner.js-0.1.0.js
@@ -63,21 +63,36 @@ define("backburner",
       instanceStack: null,
 
       begin: function() {
-        if (this.currentInstance) {
-          this.instanceStack.push(this.currentInstance);
+        var onBegin = this.options && this.options.onBegin,
+            previousInstance = this.currentInstance;
+
+        if (previousInstance) {
+          this.instanceStack.push(previousInstance);
         }
 
         this.currentInstance = new DeferredActionQueues(this.queueNames, this.options);
+        if (onBegin) {
+          onBegin(this.currentInstance, previousInstance);
+        }
       },
 
       end: function() {
+        var onEnd = this.options && this.options.onEnd,
+            currentInstance = this.currentInstance,
+            nextInstance = null;
+
         try {
-          this.currentInstance.flush();
+          currentInstance.flush();
         } finally {
           this.currentInstance = null;
 
           if (this.instanceStack.length) {
-            this.currentInstance = this.instanceStack.pop();
+            nextInstance = this.instanceStack.pop();
+            this.currentInstance = nextInstance;
+          }
+
+          if (onEnd) {
+            onEnd(currentInstance, nextInstance);
           }
         }
       },
@@ -356,7 +371,7 @@ define("backburner/deferred_action_queues",
           var options = queue.options,
               before = options && options.before,
               after = options && options.after,
-              target, method, args,
+              target, method, args, stack,
               queueIndex = 0, numberOfQueueItems = queueItems.length;
 
           if (numberOfQueueItems && before) { before(); }
@@ -364,6 +379,7 @@ define("backburner/deferred_action_queues",
             target = queueItems[queueIndex];
             method = queueItems[queueIndex+1];
             args   = queueItems[queueIndex+2];
+            stack  = queueItems[queueIndex+3]; // Debugging assistance
 
             if (typeof method === 'string') { method = target[method]; }
 
@@ -450,13 +466,14 @@ define("backburner/queue",
             options = this.options,
             before = options && options.before,
             after = options && options.after,
-            action, target, method, args, i, l = queue.length;
+            action, target, method, args, stack, i, l = queue.length;
 
         if (l && before) { before(); }
         for (i = 0; i < l; i += 4) {
           target = queue[i];
           method = queue[i+1];
           args   = queue[i+2];
+          stack  = queue[i+3]; // Debugging assistance
 
           // TODO: error handling
           if (args && args.length > 0) {

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -22,21 +22,36 @@ Backburner.prototype = {
   instanceStack: null,
 
   begin: function() {
-    if (this.currentInstance) {
-      this.instanceStack.push(this.currentInstance);
+    var onBegin = this.options && this.options.onBegin,
+        previousInstance = this.currentInstance;
+
+    if (previousInstance) {
+      this.instanceStack.push(previousInstance);
     }
 
     this.currentInstance = new DeferredActionQueues(this.queueNames, this.options);
+    if (onBegin) {
+      onBegin(this.currentInstance, previousInstance);
+    }
   },
 
   end: function() {
+    var onEnd = this.options && this.options.onEnd,
+        currentInstance = this.currentInstance,
+        nextInstance = null;
+
     try {
-      this.currentInstance.flush();
+      currentInstance.flush();
     } finally {
       this.currentInstance = null;
 
       if (this.instanceStack.length) {
-        this.currentInstance = this.instanceStack.pop();
+        nextInstance = this.instanceStack.pop();
+        this.currentInstance = nextInstance;
+      }
+
+      if (onEnd) {
+        onEnd(currentInstance, nextInstance);
       }
     }
   },

--- a/test/tests/backburner_test.js
+++ b/test/tests/backburner_test.js
@@ -490,3 +490,37 @@ test("Default queue can be manually configured", function() {
 
   equal(bb.options.defaultQueue, 'two');
 });
+
+test("onBegin and onEnd are called and passed the correct parameters", function() {
+  expect(2);
+
+  var befores = [],
+      afters = [],
+      expectedBefores = [],
+      expectedAfters = [],
+      outer, inner;
+
+  var bb = new Backburner(['one'], {
+    onBegin: function(current, previous) {
+      befores.push(current);
+      befores.push(previous);
+    },
+    onEnd: function(current, next) {
+      afters.push(current);
+      afters.push(next);
+    }
+  });
+
+  bb.run(function() {
+    outer = bb.currentInstance;
+    bb.run(function() {
+      inner = bb.currentInstance;
+    });
+  });
+
+  expectedBefores = [outer, null, inner, outer];
+  expectedAfters = [inner, outer, outer, null];
+
+  deepEqual(befores, expectedBefores, "before callbacks successful");
+  deepEqual(afters, expectedAfters, "after callback successful");
+});


### PR DESCRIPTION
Added `beforeLoop` and `afterLoop` callbacks to backburner's options.

`beforeLoop` gets called whenever a run loop is started. It gets the currently starting loop as a first parameter, and the previous loop (if any) as a second parameter.

`afterLoop` gets called whenever a run loop is flushed. It gets the currently ending loop as a first parameter, and the next loop (i.e the wrapping loop if any) as a second parameter.

This is useful to run methods on start / end of run loops.  Example use in Ember.js is keeping track of `Ember.run.currentRunLoop:`

``` js
var backburner = new Backburner(['sync', 'actions'], {
  beforeLoop: function(currentLoop, previousLoop) {
    Ember.run.currentRunLoop = currentLoop;
  }), 
  afterLoop: function(currentLoop, nextLoop) {
    Ember.run.currentRunLoop = nextLoop;
  }
});
```
