### PR TITLE
Fix `setTimeout` to be overridable

### DIFF
--- a/dist/backburner.js-0.1.0.amd.js
+++ b/dist/backburner.js-0.1.0.amd.js
@@ -222,7 +222,8 @@ define("backburner",
         pop = [].pop,
         debouncees = [],
         timers = [],
-        autorun, laterTimer, laterTimerExpiresAt;
+        autorun, laterTimer, laterTimerExpiresAt,
+        global = this;
 
     function Backburner(queueNames, options) {
       this.queueNames = queueNames;
@@ -379,7 +380,7 @@ define("backburner",
           clearTimeout(laterTimer);
           laterTimer = null;
         }
-        laterTimer = window.setTimeout(function() {
+        laterTimer = global.setTimeout(function() {
           executeTimers(self);
           laterTimer = null;
           laterTimerExpiresAt = null;
@@ -400,7 +401,7 @@ define("backburner",
           if (debouncee[0] === target && debouncee[1] === method) { return; } // do nothing
         }
 
-        var timer = window.setTimeout(function() {
+        var timer = global.setTimeout(function() {
           self.run.apply(self, args);
 
           // remove debouncee
@@ -463,7 +464,7 @@ define("backburner",
 
     function createAutorun(backburner) {
       backburner.begin();
-      autorun = window.setTimeout(function() {
+      autorun = global.setTimeout(function() {
         backburner.end();
         autorun = null;
       });
@@ -488,7 +489,7 @@ define("backburner",
       });
 
       if (timers.length) {
-        laterTimer = window.setTimeout(function() {
+        laterTimer = global.setTimeout(function() {
           executeTimers(self);
           laterTimer = null;
           laterTimerExpiresAt = null;

--- a/dist/backburner.js-0.1.0.js
+++ b/dist/backburner.js-0.1.0.js
@@ -261,7 +261,8 @@ define("backburner",
         pop = [].pop,
         debouncees = [],
         timers = [],
-        autorun, laterTimer, laterTimerExpiresAt;
+        autorun, laterTimer, laterTimerExpiresAt,
+        global = this;
 
     function Backburner(queueNames, options) {
       this.queueNames = queueNames;
@@ -418,7 +419,7 @@ define("backburner",
           clearTimeout(laterTimer);
           laterTimer = null;
         }
-        laterTimer = window.setTimeout(function() {
+        laterTimer = global.setTimeout(function() {
           executeTimers(self);
           laterTimer = null;
           laterTimerExpiresAt = null;
@@ -439,7 +440,7 @@ define("backburner",
           if (debouncee[0] === target && debouncee[1] === method) { return; } // do nothing
         }
 
-        var timer = window.setTimeout(function() {
+        var timer = global.setTimeout(function() {
           self.run.apply(self, args);
 
           // remove debouncee
@@ -502,7 +503,7 @@ define("backburner",
 
     function createAutorun(backburner) {
       backburner.begin();
-      autorun = window.setTimeout(function() {
+      autorun = global.setTimeout(function() {
         backburner.end();
         autorun = null;
       });
@@ -527,7 +528,7 @@ define("backburner",
       });
 
       if (timers.length) {
-        laterTimer = window.setTimeout(function() {
+        laterTimer = global.setTimeout(function() {
           executeTimers(self);
           laterTimer = null;
           laterTimerExpiresAt = null;

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -4,7 +4,8 @@ var slice = [].slice,
     pop = [].pop,
     debouncees = [],
     timers = [],
-    autorun, laterTimer, laterTimerExpiresAt, setTimeout;
+    autorun, laterTimer, laterTimerExpiresAt,
+    global = this;
 
 function Backburner(queueNames, options) {
   this.queueNames = queueNames;
@@ -13,12 +14,6 @@ function Backburner(queueNames, options) {
     this.options.defaultQueue = queueNames[0];
   }
   this.instanceStack = [];
-}
-
-if(typeof window === 'undefined') {
-  setTimeout = this.setTimeout;
-} else {
-  setTimeout = window.setTimeout;
 }
 
 Backburner.prototype = {
@@ -167,7 +162,7 @@ Backburner.prototype = {
       clearTimeout(laterTimer);
       laterTimer = null;
     }
-    laterTimer = setTimeout(function() {
+    laterTimer = global.setTimeout(function() {
       executeTimers(self);
       laterTimer = null;
       laterTimerExpiresAt = null;
@@ -188,7 +183,7 @@ Backburner.prototype = {
       if (debouncee[0] === target && debouncee[1] === method) { return; } // do nothing
     }
 
-    var timer = setTimeout(function() {
+    var timer = global.setTimeout(function() {
       self.run.apply(self, args);
 
       // remove debouncee
@@ -251,7 +246,7 @@ Backburner.prototype.later = Backburner.prototype.setTimeout;
 
 function createAutorun(backburner) {
   backburner.begin();
-  autorun = setTimeout(function() {
+  autorun = global.setTimeout(function() {
     backburner.end();
     autorun = null;
   });
@@ -276,7 +271,7 @@ function executeTimers(self) {
   });
 
   if (timers.length) {
-    laterTimer = setTimeout(function() {
+    laterTimer = global.setTimeout(function() {
       executeTimers(self);
       laterTimer = null;
       laterTimerExpiresAt = null;


### PR DESCRIPTION
In Ember.js, `setTimeout` is overridden on timer tests.
But it couldn't without receiver.
