### PR TITLE
`autorun` timeout should be nullified before calling `backburner.end()`

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -296,8 +296,8 @@ Backburner.prototype.later = Backburner.prototype.setTimeout;
 function createAutorun(backburner) {
   backburner.begin();
   autorun = global.setTimeout(function() {
-    backburner.end();
     autorun = null;
+    backburner.end();
   });
 }
 


### PR DESCRIPTION
`autorun` timeout should be nullified before calling `backburner.end()`, otherwise `Backburner.prototype.hasTimers()` will return a truthy value when an error is thrown inside `backburner.end()`.

The fix is really simple.

But I couldn't find a good way to write a test for it, since the test needs an exception thrown and I couldn't figure out how to ignore that specific exception. Here is a test that shows the issue:

``` javascript
asyncTest("autorun that throws error", function() {
    var bb = new Backburner(['zomg']);

    bb.schedule('zomg', null, function() {
        setTimeout(function() {
            ok(!bb.hasTimers(), "All timers are cleared");
            start();
        });
        throw new Error('Just for fun.');
    });
});
```

It will fail with this message:

```
Running "qunit:all" (qunit) task
Testing test/index.html .F...........................................
>> autorun - autorun that throws error
>> Message: Error: Just for fun.
>> file:///Users/sebsei/projects/oss/backburner.js/tmp/tests.js:78

>> autorun - autorun that throws error
>> Message: All timers are cleared
>> at file:///Users/sebsei/projects/oss/backburner.js/test/lib/qunit-1.11.0.js:521
>>   at file:///Users/sebsei/projects/oss/backburner.js/tmp/tests.js:75
```

Using my fix, only the `Error: Just for fun.` will fail (which is expected).

If anybody can come up with a good way to expect an error to be thrown asynchronously in QUnit I would gladly add that test.
