### PR TITLE
ability to cancel debounce and throttle

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -199,30 +199,25 @@ Backburner.prototype = {
     var self = this,
         args = arguments,
         wait = parseInt(pop.call(args), 10),
-        throttler;
+        throttler,
+        index,
+        timer;
 
-    for (var i = 0, l = throttlers.length; i < l; i++) {
-      throttler = throttlers[i];
-      if (throttler[0] === target && throttler[1] === method) { return; } // do nothing
-    }
+    index = findThrottler(target, method);
+    if (index > -1) { return throttlers[index]; } // throttled
 
-    var timer = global.setTimeout(function() {
+    timer = global.setTimeout(function() {
       self.run.apply(self, args);
 
-      // remove throttler
-      var index = -1;
-      for (var i = 0, l = throttlers.length; i < l; i++) {
-        throttler = throttlers[i];
-        if (throttler[0] === target && throttler[1] === method) {
-          index = i;
-          break;
-        }
-      }
-
+      var index = findThrottler(target, method);
       if (index > -1) { throttlers.splice(index, 1); }
     }, wait);
 
-    throttlers.push([target, method, timer]);
+    throttler = [target, method, timer];
+
+    throttlers.push(throttler);
+
+    return throttler;
   },
 
   debounce: function(target, method /* , args, wait, [immediate] */) {
@@ -231,7 +226,8 @@ Backburner.prototype = {
         immediate = pop.call(args),
         wait,
         index,
-        debouncee;
+        debouncee,
+        timer;
 
     if (typeof immediate === "number" || typeof immediate === "string") {
       wait = immediate;
@@ -244,18 +240,18 @@ Backburner.prototype = {
     // Remove debouncee
     index = findDebouncee(target, method);
 
-    if (index !== -1) {
+    if (index > -1) {
       debouncee = debouncees[index];
       debouncees.splice(index, 1);
       clearTimeout(debouncee[2]);
     }
 
-    var timer = global.setTimeout(function() {
+    timer = global.setTimeout(function() {
       if (!immediate) {
         self.run.apply(self, args);
       }
-      index = findDebouncee(target, method);
-      if (index) {
+      var index = findDebouncee(target, method);
+      if (index > -1) {
         debouncees.splice(index, 1);
       }
     }, wait);
@@ -264,7 +260,11 @@ Backburner.prototype = {
       self.run.apply(self, args);
     }
 
-    debouncees.push([target, method, timer]);
+    debouncee = [target, method, timer];
+
+    debouncees.push(debouncee);
+
+    return debouncee;
   },
 
   cancelTimers: function() {
@@ -297,19 +297,47 @@ Backburner.prototype = {
   },
 
   cancel: function(timer) {
-    if (timer && typeof timer === 'object' && timer.queue && timer.method) { // we're cancelling a deferOnce
+    var timerType = typeof timer;
+
+    if (timer && timerType === 'object' && timer.queue && timer.method) { // we're cancelling a deferOnce
       return timer.queue.cancel(timer);
-    } else if (typeof timer === 'function') { // we're cancelling a setTimeout
+    } else if (timerType === 'function') { // we're cancelling a setTimeout
       for (var i = 0, l = timers.length; i < l; i += 2) {
         if (timers[i + 1] === timer) {
           timers.splice(i, 2); // remove the two elements
           return true;
         }
       }
+    } else if (window.toString.call(timer) === "[object Array]"){ // we're cancelling a throttle or debounce
+      return this._cancelItem(findThrottler, throttlers, timer) || 
+               this._cancelItem(findDebouncee, debouncees, timer);
     } else {
       return; // timer was null or not a timer
     }
+  },
+
+  _cancelItem: function(findMethod, array, timer){
+    var item,
+        index;
+
+    if (timer.length < 3) { return false; }
+
+    index = findMethod(timer[0], timer[1]);
+
+    if(index > -1) {
+
+      item = array[index];
+
+      if(item[2] === timer[2]){
+        array.splice(index, 1);
+        clearTimeout(timer[2]);
+        return true;
+      }
+    }
+
+    return false;
   }
+
 };
 
 Backburner.prototype.schedule = Backburner.prototype.defer;
@@ -368,6 +396,21 @@ function findDebouncee(target, method) {
   for (var i = 0, l = debouncees.length; i < l; i++) {
     debouncee = debouncees[i];
     if (debouncee[0] === target && debouncee[1] === method) {
+      index = i;
+      break;
+    }
+  }
+
+  return index;
+}
+
+function findThrottler(target, method) {
+  var throttler,
+      index = -1;
+
+  for (var i = 0, l = throttlers.length; i < l; i++) {
+    throttler = throttlers[i];
+    if (throttler[0] === target && throttler[1] === method) {
       index = i;
       break;
     }

--- a/test/tests/throttle_test.js
+++ b/test/tests/throttle_test.js
@@ -103,3 +103,83 @@ test("throttle", function() {
     }, 110);
   }, 180);
 });
+
+test("throttle returns timer information usable for cancelling", function() {
+  expect(3);
+
+  var bb = new Backburner(['batman']),
+      timer;
+
+  var wasCalled = false;
+
+  function throttler() {
+    ok(false, "this method shouldn't be called");
+    wasCalled = true;
+  }
+
+  timer = bb.throttle(null, throttler, 1);
+
+  ok(bb.cancel(timer), "the timer is cancelled");
+
+  //should return false second time around
+  ok(!bb.cancel(timer), "the timer no longer exists in the list");
+
+  stop();
+  setTimeout(function() {
+    start();
+    ok(!wasCalled, "the timer wasn't called after waiting");
+  }, 60);
+
+});
+
+test("throttler cancel after it's executed returns false", function() {
+  expect(3);
+
+  var bb = new Backburner(['darkknight']),
+      timer;
+
+  var wasCalled = false;
+
+  function throttler() {
+    ok(true, "the throttled method was called");
+    wasCalled = true;
+  }
+
+  timer = bb.throttle(null, throttler, 1);
+
+  stop();
+  setTimeout(function() {
+    start();
+    ok(!bb.cancel(timer), "no timer existed to cancel");
+    ok(wasCalled, "the timer was actually called");
+  }, 10);
+
+});
+
+test("throttler returns the appropriate timer to cancel if the old item still exists", function() {
+  expect(5);
+
+  var bb = new Backburner(['robin']),
+      timer,
+      timer2;
+
+  var wasCalled = false;
+
+  function throttler() {
+    ok(true, "the throttled method was called");
+    wasCalled = true;
+  }
+
+  timer = bb.throttle(null, throttler, 1);
+  timer2 = bb.throttle(null, throttler, 1);
+  deepEqual(timer, timer2, "the same timer was returned");
+
+  stop();
+  setTimeout(function() {
+    start();
+    bb.throttle(null, throttler, 1);
+    ok(!bb.cancel(timer), "the second timer isn't removed, despite appearing to be the same item");
+    ok(wasCalled, "the timer was actually called");
+  }, 10);
+
+});


### PR DESCRIPTION
Essentially return identifiers to anyone who calls debounce/throttle so 
it can be used to cancel the throttle/debounce.

Additionally fix a bug where debounced item in index 0 isn't
removed unless debounce for that target/method is called again, but
then it's in index 0 and then isn't removed
