### PR TITLE
Add binary search

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -157,6 +157,8 @@ Backburner.prototype = {
 
       if (isCoercableNumber(last)) {
         wait = args.pop();
+      } else {
+        wait = 0;
       }
 
       methodOrTarget = args[0];
@@ -182,11 +184,8 @@ Backburner.prototype = {
       method.apply(target, args);
     }
 
-    // find position to insert - TODO: binary search
-    var i, l;
-    for (i = 0, l = timers.length; i < l; i += 2) {
-      if (executeAt < timers[i]) { break; }
-    }
+    // find position to insert
+    var i = searchTimer(executeAt, timers, 0, timers.length - 2);
 
     timers.splice(i, 0, executeAt, fn);
 
@@ -386,11 +385,7 @@ function executeTimers(self) {
       time, fns, i, l;
 
   self.run(function() {
-    // TODO: binary search
-    for (i = 0, l = timers.length; i < l; i += 2) {
-      time = timers[i];
-      if (time > now) { break; }
-    }
+    i = searchTimer(now, timers, 0, timers.length - 2);
 
     fns = timers.splice(0, i);
 
@@ -432,6 +427,25 @@ function findThrottler(target, method) {
   }
 
   return index;
+}
+
+function searchTimer(time, timers, start, end) {
+  var middle;
+
+  while (start < end) {
+    middle = start + Math.floor((end - start)/4);
+    if (time >= timers[middle]) {
+      start = middle + 2;
+    } else {
+      end = middle;
+    }
+  }
+
+  if (timers[start] !== undefined && time > timers[start]) {
+    return start + 2;
+  } else {
+    return start;
+  }
 }
 
 export { Backburner };

--- a/test/tests/set_timeout_test.js
+++ b/test/tests/set_timeout_test.js
@@ -22,14 +22,14 @@ test("setTimeout", function() {
 
   stop();
   bb.setTimeout(null, function() {
-    start();
-    instance = bb.currentInstance;
-    equal(step++, 0);
+    equal(step++, 1);
+    equal(instance, bb.currentInstance, "same instance");
   }, 10);
 
   bb.setTimeout(null, function() {
-    equal(step++, 1);
-    equal(instance, bb.currentInstance, "same instance");
+    start();
+    instance = bb.currentInstance;
+    equal(step++, 0);
   }, 10);
 
   Date.prototype.valueOf = originalDateValueOf;
@@ -98,7 +98,7 @@ test("[null, callback, undefined]", function(){
   }, undefined);
 });
 
-test("[null, callback, undefined]", function(){
+test("[null, callback, null]", function(){
   expect(3);
   stop();
   bb.setTimeout(null, function() {
@@ -109,7 +109,7 @@ test("[null, callback, undefined]", function(){
   }, null);
 });
 
-test("[null, callback, undefined]", function(){
+test("[callback, string, string, string]", function(){
   expect(5);
   stop();
   bb.setTimeout(function() {
@@ -122,7 +122,7 @@ test("[null, callback, undefined]", function(){
   }, 'a', 'b', 'c');
 });
 
-test("[null, callback, undefined]", function(){
+test("[null, callback, string, string, string]", function(){
   expect(5);
   stop();
   bb.setTimeout(null, function() {
@@ -161,7 +161,7 @@ test("[null, callback, string, string, string, numericString]", function(){
   },  'a', 'b', 'c', '1');
 });
 
-test("[callback, string]", function(){
+test("[obj, string]", function(){
   expect(1);
   stop();
   bb.setTimeout({
@@ -185,7 +185,7 @@ test("[obj, string, value]", function(){
   }, 'bro', 'value');
 });
 
-test("[null, callback, undefined]", function(){
+test("[obj, string, value, number]", function(){
   stop();
   bb.setTimeout({
     bro: function(){
@@ -197,7 +197,7 @@ test("[null, callback, undefined]", function(){
   }, 'bro', 'value', 1);
 });
 
-test("[null, callback, undefined]", function(){
+test("[obj, string, value, numericString]", function(){
   stop();
   bb.setTimeout({
     bro: function(){


### PR DESCRIPTION
This commit adds binary search for timers. It also updates `timers` array
content. `timer` elements are objects with two attributes: `executeAt` and `fn`.

Other minor fixes:
- test cases titles
- `setTimeout` special case where `when` variable was not a coercable number
