### PR TITLE
Fixes grunt.build.concat.browser

### DIFF
--- a/tasks/options/concat.js
+++ b/tasks/options/concat.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   browser: {
-    src: ['vendor/loader.js', 'tmp/<%= package.barename %>.amd.js'],
+    src: ['vendor/loader.js', 'dist/<%= package.name %>-<%= package.version %>.amd.js'],
     dest: 'tmp/<%= package.barename %>.browser1.js'
   }
 };


### PR DESCRIPTION
Fixes reference to the complete AMD file. Previously it was missing the definitions for `"backburner/deferred_action_queues"` and `"backburner/queue"`
