### PR TITLE
hasTimers checks debouncees and throttlers.

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -342,7 +342,7 @@ Backburner.prototype = {
   },
 
   hasTimers: function() {
-    return !!timers.length || autorun;
+    return !!timers.length || !!debouncees.length || !!throttlers.length || autorun;
   },
 
   cancel: function(timer) {

--- a/test/tests/bb_has_timers_test.js
+++ b/test/tests/bb_has_timers_test.js
@@ -1,0 +1,36 @@
+import { Backburner } from "backburner";
+
+module("hasTimers");
+
+test("hasTimers", function () {
+  var bb = new Backburner(['ohai']),
+      timer,
+      target = {
+        fn: function () {}
+      };
+
+  bb.schedule('ohai', null, function () {
+    ok(!bb.hasTimers(), "Initially there are no timers");
+    start();
+
+    timer = bb.later('ohai', function() {});
+    ok(bb.hasTimers(), "hasTimers checks timers");
+
+    bb.cancel(timer);
+    ok(!bb.hasTimers(), "Timers are cleared");
+
+    timer = bb.debounce(target, 'fn', 200);
+    ok(bb.hasTimers(), "hasTimers checks debouncees");
+
+    bb.cancel(timer);
+    ok(!bb.hasTimers(), "Timers are cleared");
+
+    timer = bb.throttle(target, 'fn', 200);
+    ok(bb.hasTimers(), "hasTimers checks throttlers");
+
+    bb.cancel(timer);
+    ok(!bb.hasTimers(), "Timers are cleared");
+  });
+
+  stop();
+});


### PR DESCRIPTION
This ensures that ember-testing async helpers wait on debounced and throttled 
functions as well as other timers.
