### PR TITLE
Fixed binary search algorithm bug and tests

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -220,7 +220,7 @@ Backburner.prototype = {
     }
 
     // find position to insert
-    var i = searchTimer(executeAt, timers, 0, timers.length - 2);
+    var i = searchTimer(executeAt, timers);
 
     timers.splice(i, 0, executeAt, fn);
 
@@ -420,7 +420,7 @@ function executeTimers(self) {
       time, fns, i, l;
 
   self.run(function() {
-    i = searchTimer(now, timers, 0, timers.length - 2);
+    i = searchTimer(now, timers);
 
     fns = timers.splice(0, i);
 
@@ -464,11 +464,20 @@ function findThrottler(target, method) {
   return index;
 }
 
-function searchTimer(time, timers, start, end) {
-  var middle;
+function searchTimer(time, timers) {
+  var start = 0,
+      end = timers.length - 2,
+      middle, l;
 
   while (start < end) {
-    middle = start + Math.floor((end - start)/4);
+    // since timers is an array of pairs 'l' will always
+    // be an integer
+    l = (end - start) / 2;
+
+    // compensate for the index in case even number
+    // of pairs inside timers
+    middle = start + l - (l % 2);
+
     if (time >= timers[middle]) {
       start = middle + 2;
     } else {
@@ -476,11 +485,7 @@ function searchTimer(time, timers, start, end) {
     }
   }
 
-  if (timers[start] !== undefined && time > timers[start]) {
-    return start + 2;
-  } else {
-    return start;
-  }
+  return (time >= timers[start]) ? start + 2 : start;
 }
 
 export { Backburner };

--- a/test/tests/set_timeout_test.js
+++ b/test/tests/set_timeout_test.js
@@ -22,14 +22,14 @@ test("setTimeout", function() {
 
   stop();
   bb.setTimeout(null, function() {
-    equal(step++, 1);
-    equal(instance, bb.currentInstance, "same instance");
-  }, 10);
-
-  bb.setTimeout(null, function() {
     start();
     instance = bb.currentInstance;
     equal(step++, 0);
+  }, 10);
+
+  bb.setTimeout(null, function() {
+    equal(step++, 1);
+    equal(instance, bb.currentInstance, "same instance");
   }, 10);
 
   Date.prototype.valueOf = originalDateValueOf;


### PR DESCRIPTION
The 'middle' variable inside the searchTimer function was computed incorrectly. This was breaking the phantom.js tests in ember (emberjs/ember.js#4564) when upgrading to the latest backburner.
This wasn't caught by the tests because the tests were also changed in the commit 2a5534a4f6f2340c1c727c87b357926a5688ce36.
