### PR TITLE
window.postMessage for a faster runloop?

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -428,10 +428,31 @@ if (needsIETryCatchFix) {
   };
 }
 
+var nativeDefer = (function (root) {
+  var postMessage = root.postMessage,
+      queue = [],
+      messageName = 'backburner-fast-timeout';
+
+  root.addEventListener('message', function (event) {
+    if (event.source == root && event.data == messageName) {
+      event.stopPropagation();
+        if (queue.length) {
+          queue.shift()();
+        }
+    }
+  }, true);
+
+  function setFastTimeout(fn) {
+    queue.push(fn);
+    postMessage(messageName, '*');
+  }
+
+  return setFastTimeout;
+})(global);
 
 function createAutorun(backburner) {
   backburner.begin();
-  autorun = global.setTimeout(function() {
+  autorun = nativeDefer(function() {
     autorun = null;
     backburner.end();
   });


### PR DESCRIPTION
So I was thinking about how heavily Ember uses the runloop and that the timer resolution varies so incredibly wildly between browsers, sessions, star-alignment, etc and many modern browsers still have a 10ms hard min (or "clamp").

I had previous seen pretty neat things done with using `postMessage` as a way to have an almost immediate `defer`, so thought, why can't backburner use this, when it's available?

This is more of an proof of concept example then an actual PR. Doesn't include fallback to `setTimeout` and  didn't put the code in any particularly thought out place.

I just wanted to start a dialog and see if you peeps had tried this or discussed?

Btw--I am aware of issues with a couple browsers, notably [IE8](http://stevesouders.com/misc/test-postmessage.php).
