### PR TITLE
Fix for IE8

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -411,7 +411,7 @@ if (needsIETryCatchFix) {
 function wrapInTryCatch(func) {
   return function () {
     try {
-      func.apply(this, arguments);
+      return func.apply(this, arguments);
     } catch (e) {
       throw e;
     }

--- a/test/tests/run_test.js
+++ b/test/tests/run_test.js
@@ -112,6 +112,16 @@ test("runs can be nested", function() {
   });
 });
 
+test("run returns value", function() {
+  var bb = new Backburner(['one']);
+
+  var value = bb.run(function() {
+    return 'hi';
+  });
+
+  equal(value, 'hi');
+});
+
 test("onError", function() {
   expect(1);
 


### PR DESCRIPTION
`Backburner#run` is broken on IE by IE specified code.
Therefore the many tests that related `Ember.run` are failed at Ember on IE8.

This patch makes all backburner's tests happy :smile: 

Before:
![2014-05-24 2 52 52](https://cloud.githubusercontent.com/assets/290782/3069957/1a2fba18-e2a3-11e3-87f3-3381a3928e0b.png)

After:
![2014-05-24 2 54 30](https://cloud.githubusercontent.com/assets/290782/3069985/53357a0a-e2a3-11e3-9deb-bc1a60c3b21f.png)
