### PR TITLE
Removes unused variables

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -439,7 +439,7 @@ function updateLaterTimer(self, executeAt, wait) {
 
 function executeTimers(self) {
   var now = +new Date();
-  var time, fns, i, l;
+  var fns, i, l;
 
   self.run(function() {
     i = searchTimer(now, timers);

--- a/lib/backburner/queue.js
+++ b/lib/backburner/queue.js
@@ -10,7 +10,6 @@ Queue.prototype = {
   daq: null,
   name: null,
   options: null,
-  onError: null,
   _queue: null,
 
   push: function(target, method, args, stack) {


### PR DESCRIPTION
Removed following variables:
- Queue.prototype.onError - all onError callbacks are provided by the options only; the onError value on the Queue is never used
- time in executeTimers()
