### PR TITLE
Fix for unfulfilled timeout (#86)

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -427,13 +427,28 @@ function createAutorun(backburner) {
 }
 
 function updateLaterTimer(self, executeAt, wait) {
-  if (!self._laterTimer || executeAt < self._laterTimerExpiresAt) {
+  var now = (+new Date());
+  if (!self._laterTimer || executeAt < self._laterTimerExpiresAt || self._laterTimerExpiresAt < now) {
+
+    if (self._laterTimer) {
+      // Clear when:
+      // - Already expired
+      // - New timer is earlier
+      clearTimeout(self._laterTimer);
+
+      if (self._laterTimerExpiresAt < now) { // If timer was never triggered
+        // Calculate the left-over wait-time
+        wait = Math.max(0, executeAt - now);
+      }
+    }
+
     self._laterTimer = global.setTimeout(function() {
       self._laterTimer = null;
       self._laterTimerExpiresAt = null;
       executeTimers(self);
     }, wait);
-    self._laterTimerExpiresAt = executeAt;
+
+    self._laterTimerExpiresAt = now + wait;
   }
 }
 

--- a/test/tests/set_timeout_test.js
+++ b/test/tests/set_timeout_test.js
@@ -227,3 +227,72 @@ test("onError", function() {
 
   stop();
 });
+
+test("setTimeout doesn't trigger twice with earlier setTimeout", function() {
+  expect(3);
+
+  var bb = new Backburner(['one']),
+      called1 = 0,
+      called2 = 0,
+      calls = 0,
+      oldRun = bb.run;
+
+  // Count run() calls and relay them to original function
+  bb.run = function () {
+    calls++;
+    oldRun.apply(bb, arguments);
+  };
+
+  bb.setTimeout(function() {
+    called1++;
+  }, 50);
+
+  bb.setTimeout(function() {
+    called2++;
+  }, 10);
+
+  stop();
+  setTimeout(function () {
+    start();
+    equal(called1, 1, "timeout 1 was called once");
+    equal(called2, 1, "timeout 2 was called once");
+    equal(calls, 2, "run() was called twice");
+  }, 100);
+});
+
+test("setTimeout doesn't hang when timeout is unfulfilled", function() { // See issue #86
+  expect(3);
+
+  var bb = new Backburner(['one']),
+    called1 = 0,
+    called2 = 0,
+    calls = 0,
+    oldRun = bb.run;
+
+  // Count run() calls and relay them to original function
+  bb.run = function () {
+    calls++;
+    oldRun.apply(bb, arguments);
+  };
+
+  bb.setTimeout(function() {
+    called1++;
+  }, 0);
+
+  // Manually pass time and clear timeout
+  clearTimeout(bb._laterTimer);
+  bb._laterTimerExpiresAt = +(new Date()) - 5000;
+
+  bb.setTimeout(function() {
+    called2++;
+  }, 10);
+
+  stop();
+  setTimeout(function () {
+    start();
+    equal(called1, 1, "timeout 1 was called once");
+    equal(called2, 1, "timeout 2 was called once");
+    equal(calls, 1, "run() was called once"); // both at once
+  }, 50);
+});
+


### PR DESCRIPTION
This fix will also make sure that run() is called only when needed - by clearing the old timeout when a newer earlier timeout is set.

Kudos to @pashasadri as he suggested this fix.
