### PR TITLE
Update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following code will only cause a single DOM manipulation:
     <script src="backburner.js"></script>
 
     <script>
-      var bb = new backburner.Backburner(['render']),
+      var backburner = new Backburner(['render']),
           person = {name: "Erik"};
 
       function updateName() {
@@ -57,10 +57,10 @@ The following code will only cause a single DOM manipulation:
 
       function setName(name) {
         person.name = name;
-        bb.deferOnce('render', updateName);
+        backburner.deferOnce('render', updateName);
       }
 
-      bb.run(function() {
+      backburner.run(function() {
         setName("Kris");
         setName("Tom");
         setName("Yehuda");


### PR DESCRIPTION
Current example uses `var backburner = Backburner.new( ...` which does not run because the constructor is actually available as  `window.backburner.Backburner`. Rework the example to fix this. Also added the surrounding HTML to make running the example just a copy & paste operation which is nicer for newbies I think. Happy to revert the HTML stuff if you would prefer - just let me know.
