### PR TITLE
[Perf inspired by#71] don’t attempt to flush empty queue, merely skip to...

### DIFF
--- a/lib/backburner/deferred-action-queues.js
+++ b/lib/backburner/deferred-action-queues.js
@@ -66,6 +66,13 @@ DeferredActionQueues.prototype = {
     while (queueNameIndex < numberOfQueues) {
       queueName = queueNames[queueNameIndex];
       queue = queues[queueName];
+
+      var numberOfQueueItems = queue._queue.length;
+      if (numberOfQueueItems === 0) {
+        queueNameIndex++;
+        continue;
+      }
+
       queueItems = queue._queueBeingFlushed = queue._queue.slice();
       queue._queue = [];
       queue.targetQueues = Object.create(null);
@@ -75,9 +82,8 @@ DeferredActionQueues.prototype = {
       var after = queueOptions && queueOptions.after;
       var target, method, args, errorRecordedForStack;
       var queueIndex = 0;
-      var numberOfQueueItems = queueItems.length;
 
-      if (numberOfQueueItems && before) {
+      if (before) {
         before();
       }
 
@@ -86,8 +92,6 @@ DeferredActionQueues.prototype = {
         method                = queueItems[queueIndex+1];
         args                  = queueItems[queueIndex+2];
         errorRecordedForStack = queueItems[queueIndex+3]; // Debugging assistance
-
-        //
 
         if (isString(method)) {
           method = target[method];
@@ -114,29 +118,13 @@ DeferredActionQueues.prototype = {
       }
 
       queue._queueBeingFlushed = null;
-      if (numberOfQueueItems && after) {
+      if (after) {
         after();
       }
 
-      if ((priorQueueNameIndex = indexOfPriorQueueWithActions(this, queueNameIndex)) !== -1) {
-        queueNameIndex = priorQueueNameIndex;
-      } else {
-        queueNameIndex++;
-      }
+      queueNameIndex = 0;
     }
   }
 };
-
-function indexOfPriorQueueWithActions(daq, currentQueueIndex) {
-  var queueName, queue;
-
-  for (var i = 0, l = currentQueueIndex; i <= l; i++) {
-    queueName = daq.queueNames[i];
-    queue = daq.queues[queueName];
-    if (queue._queue.length) { return i; }
-  }
-
-  return -1;
-}
 
 export default DeferredActionQueues;


### PR DESCRIPTION
... the next queue
- don’t both allocating a new intermediate queue if it is empty
- don’t bother trying to invoke all the callbacks for a clearly empty queue
- don’t both trying to flush the empty queue
- don’t bother trying to see if the empty queue scheduled something on a previous queue

instead
- check if we need to flush the current queue
  -  if it needs to be flushed: flush, then return to the first queue and try again
  - if not, try the next queue

@krisselden r?
related: #71 
