### PR TITLE
Add join method

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -119,6 +119,23 @@ Backburner.prototype = {
     }
   },
 
+  join: function(target, method /*, args */) {
+    if (this.currentInstance) {
+      if (!method) {
+        method = target;
+        target = null;
+      }
+
+      if (isString(method)) {
+        method = target[method];
+      }
+
+      return method.apply(target, slice.call(arguments, 2));
+    } else {
+      return this.run.apply(this, arguments);
+    }
+  },
+
   defer: function(queueName, target, method /* , args */) {
     if (!method) {
       method = target;

--- a/tests/join_test.js
+++ b/tests/join_test.js
@@ -1,0 +1,103 @@
+import Backburner from "backburner";
+
+module("join");
+
+function depth(bb) {
+  return bb.instanceStack.length + (bb.currentInstance ? 1 : 0);
+}
+
+test("outside of a run loop", function() {
+  expect(4);
+
+  var bb = new Backburner(['one']);
+
+  equal(depth(bb), 0);
+  var result = bb.join(function() {
+    equal(depth(bb), 1);
+    return "result";
+  });
+  equal(result, "result");
+  equal(depth(bb), 0);
+});
+
+test("inside of a run loop", function() {
+  expect(4);
+
+  var bb = new Backburner(['one']);
+
+  equal(depth(bb), 0);
+  bb.run(function() {
+    var result = bb.join(function() {
+      equal(depth(bb), 1);
+      return "result";
+    });
+    equal(result, "result");
+  });
+  equal(depth(bb), 0);
+});
+
+test("nested join calls", function() {
+  expect(7);
+
+  var bb = new Backburner(['one']);
+
+  equal(depth(bb), 0);
+  bb.join(function() {
+    equal(depth(bb), 1);
+    bb.join(function() {
+      equal(depth(bb), 1);
+      bb.join(function() {
+        equal(depth(bb), 1);
+      });
+      equal(depth(bb), 1);
+    });
+    equal(depth(bb), 1);
+  });
+  equal(depth(bb), 0);
+});
+
+test("nested run loops", function() {
+  expect(7);
+
+  var bb = new Backburner(['one']);
+
+  equal(depth(bb), 0);
+  bb.join(function() {
+    equal(depth(bb), 1);
+    bb.run(function() {
+      equal(depth(bb), 2);
+      bb.join(function() {
+        equal(depth(bb), 2);
+      });
+      equal(depth(bb), 2);
+    });
+    equal(depth(bb), 1);
+  });
+  equal(depth(bb), 0);
+});
+
+test("queue execution order", function() {
+  expect(1);
+
+  var bb = new Backburner(['one']);
+  var items = [];
+
+  bb.run(function() {
+    items.push(0);
+    bb.schedule('one', function() {
+      items.push(4);
+    });
+    bb.join(function() {
+      items.push(1);
+      bb.schedule('one', function() {
+        items.push(5);
+      });
+      items.push(2);
+    });
+    bb.schedule('one', function() {
+      items.push(6);
+    });
+    items.push(3);
+  });
+  deepEqual(items, [0, 1, 2, 3, 4, 5, 6]);
+});


### PR DESCRIPTION
The join method is like the run method except that it will schedule into an existing queue if one exists. In either case, the join method will immediately execute the passed in function and returns its result.
