### PR TITLE
Fix more possible deopts

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -16,7 +16,6 @@ import searchTimer from "backburner/binary-search";
 
 import DeferredActionQueues from "backburner/deferred-action-queues";
 
-var slice = [].slice;
 var pop = [].pop;
 var global = this;
 
@@ -77,21 +76,34 @@ Backburner.prototype = {
     }
   },
 
-  run: function(target, method /*, args */) {
-    var onError = getOnError(this.options);
+  run: function(/* target, method, args */) {
+    var length = arguments.length;
+    var method, target, args;
 
-    this.begin();
-
-    if (!method) {
-      method = target;
+    if (length === 1) {
+      method = arguments[0];
       target = null;
+    } else {
+      target = arguments[0];
+      method = arguments[1];
     }
 
     if (isString(method)) {
       method = target[method];
     }
 
-    var args = slice.call(arguments, 2);
+    if (length > 2) {
+      args = new Array(length - 2);
+      for (var i = 0, l = length - 2; i < l; i++) {
+        args[i] = arguments[i + 2];
+      }
+    } else {
+      args = [];
+    }
+
+    var onError = getOnError(this.options);
+
+    this.begin();
 
     // guard against Safari 6's double-finally bug
     var didFinally = false;
@@ -119,11 +131,11 @@ Backburner.prototype = {
     }
   },
 
-  join: function(/* target, method , args */) {
-    var method, target;
-
+  join: function(/* target, method, args */) {
     if (this.currentInstance) {
       var length = arguments.length;
+      var method, target;
+
       if (length === 1) {
         method = arguments[0];
         target = null;
@@ -142,7 +154,7 @@ Backburner.prototype = {
         return method.call(target);
       } else {
         var args = new Array(length - 2);
-        for (var i =0, l = length - 2; i < l; i++) {
+        for (var i = 0, l = length - 2; i < l; i++) {
           args[i] = arguments[i + 2];
         }
         return method.apply(target, args);
@@ -152,10 +164,16 @@ Backburner.prototype = {
     }
   },
 
-  defer: function(queueName, target, method /* , args */) {
-    if (!method) {
-      method = target;
+  defer: function(queueName /* , target, method, args */) {
+    var length = arguments.length;
+    var method, target, args;
+
+    if (length === 2) {
+      method = arguments[1];
       target = null;
+    } else {
+      target = arguments[1];
+      method = arguments[2];
     }
 
     if (isString(method)) {
@@ -163,8 +181,6 @@ Backburner.prototype = {
     }
 
     var stack = this.DEBUG ? new Error() : undefined;
-    var length = arguments.length;
-    var args;
 
     if (length > 3) {
       args = new Array(length - 3);
@@ -179,10 +195,16 @@ Backburner.prototype = {
     return this.currentInstance.schedule(queueName, target, method, args, false, stack);
   },
 
-  deferOnce: function(queueName, target, method /* , args */) {
-    if (!method) {
-      method = target;
+  deferOnce: function(queueName /* , target, method, args */) {
+    var length = arguments.length;
+    var method, target, args;
+
+    if (length === 2) {
+      method = arguments[1];
       target = null;
+    } else {
+      target = arguments[1];
+      method = arguments[2];
     }
 
     if (isString(method)) {
@@ -190,8 +212,6 @@ Backburner.prototype = {
     }
 
     var stack = this.DEBUG ? new Error() : undefined;
-    var length = arguments.length;
-    var args;
 
     if (length > 3) {
       args = new Array(length - 3);


### PR DESCRIPTION
- Removes argument rewriting for `run`/`defer`/`deferOnce`.
- Manually splice arguments in `run` (this shouldn't matter much since run isn't called very often, I can revert it since it's so verbose.)
