### PR TITLE
backburner yield features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ A rewrite of the Ember.js run loop as a generic microlibrary.
 
 ### Constructor
 
-`new Backburner()` - instantiate a Backburner instance with an array of queue names
+`new Backburner([queue names], options)` - instantiate a Backburner instance with an array of queue names
+
+### options
+
+`yieldInterval` - [integer] sets a time interval for task yielding. Omitting or setting to zero instructs backburner to flush all queues without stopping until all taskes have been processed. This is the fastest way to process your app's tasks, however, this approach can lead to Jank in the UI if it takes longer than say >50ms for your app's tasks to run. Assinging a value between 10 and 100 will substantially reduce Jank in your app by creating pauses in task processing which allows the browser to run it's normal paint cycle.  The flip side is that it will increase the time it takes for all your app's tasks to be processed (paint time can add up).
+
 
 ### Instance methods
 

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -98,7 +98,7 @@ Backburner.prototype = {
     }
 
     if (!result.done){
-      if (!this.yieldFilter || this.yeildFilter(currentInstance)) {
+      if (!this.yieldFilter || this.yeildFilter && this.yeildFilter(currentInstance)) {
         setTimeout(function () {
           that.burnCycle();
         }, 0);

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -77,6 +77,7 @@ Backburner.prototype = {
     var endTime = startTime;
     var result = {};
     var currentInstance = this.currentInstance;
+    var that = this;
 
     if (!this.burnCycleStartTime) {
       this.burnCycleStartTime = startTime;
@@ -96,7 +97,7 @@ Backburner.prototype = {
     }
 
     if (!result.done){
-      requestAnimationFrame(this.burnCycle.bind(this));
+      setTimeout(function(){that.burnCycle()},0);
     } else {
       if (this.onBurnCycle) {
         this.onBurnCycle({
@@ -110,7 +111,8 @@ Backburner.prototype = {
   },
 
   startBurnCycle: function() {
-    requestAnimationFrame(this.burnCycle.bind(this));
+    var that = this;
+    setTimeout(function(){that.burnCycle()},0);
   },
 
   end: function() {

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -118,8 +118,7 @@ Backburner.prototype = {
   },
 
   startBurnCycle: function() {
-    var that = this;
-    setTimeout(function(){that.burnCycle()},0);
+    this.burnCycle();
   },
 
   end: function() {

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -98,7 +98,7 @@ Backburner.prototype = {
     }
 
     if (!result.done){
-      if (!this.yieldFilter || this.yeildFilter && this.yeildFilter(currentInstance)) {
+      if (!this.yieldFilter || this.yieldFilter(currentInstance)) {
         setTimeout(function () {
           that.burnCycle();
         }, 0);

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -37,6 +37,11 @@ export default function Backburner(queueNames, options) {
   this._boundRunExpiredTimers = function () {
     _this._runExpiredTimers();
   };
+
+  this.yieldInterval = options && options.yieldInterval || 0;
+  this.onNext = options && options.onNext;
+  this.burnCycleStartTime = 0;
+  this.onBurnCycle = options && options.onBurnCycle;
 }
 
 // ms of delay before we conclude a timeout was lost
@@ -59,11 +64,62 @@ Backburner.prototype = {
     }
   },
 
-  end: function() {
-    var options = this.options;
-    var onEnd = options && options.onEnd;
+  getYieldInterval: function() {
+    return this.yieldInterval;
+  },
+
+  getTime: function() {
+    return new Date().getTime();
+  },
+
+  burnCycle: function() {
+    var startTime = this.getTime();
+    var endTime = startTime;
+    var result = {};
     var currentInstance = this.currentInstance;
-    var nextInstance = null;
+
+    if (!this.burnCycleStartTime) {
+      this.burnCycleStartTime = startTime;
+    }
+
+    while (!result.done && startTime > endTime - this.getYieldInterval()) {
+      result = currentInstance.next();
+      endTime = this.getTime();
+    }
+
+    if (this.onNext) {
+      this.onNext({
+        selfTime: endTime - startTime,
+        currentInstance: currentInstance,
+        result: result
+      });
+    }
+
+    if (!result.done){
+      requestAnimationFrame(this.burnCycle.bind(this));
+    } else {
+      if (this.onBurnCycle) {
+        this.onBurnCycle({
+          selfTime: endTime - this.burnCycleStartTime,
+          currentInstance: currentInstance
+        });
+      }
+      this.burnCycleStartTime = 0;
+      this.popInstanceStack();
+    }
+  },
+
+  startBurnCycle: function() {
+    requestAnimationFrame(this.burnCycle.bind(this));
+  },
+
+  end: function() {
+    var currentInstance = this.currentInstance;
+
+    if (this.getYieldInterval()) {
+      this.startBurnCycle();
+      return;
+    }
 
     // Prevent double-finally bug in Safari 6.0.2 and iOS 6
     // This bug appears to be resolved in Safari 6.0.5 and iOS 7
@@ -73,20 +129,28 @@ Backburner.prototype = {
     } finally {
       if (!finallyAlreadyCalled) {
         finallyAlreadyCalled = true;
-
-        this.currentInstance = null;
-
-        if (this.instanceStack.length) {
-          nextInstance = this.instanceStack.pop();
-          this.currentInstance = nextInstance;
-        }
-        this._trigger('end', currentInstance, nextInstance);
-        if (onEnd) {
-          onEnd(currentInstance, nextInstance);
-        }
+        this.popInstanceStack();
       }
     }
   },
+
+  popInstanceStack: function() {
+    var options = this.options;
+    var onEnd = options && options.onEnd;
+    var nextInstance = null;
+    var currentInstance = this.currentInstance;
+    this.currentInstance = null;
+
+    if (this.instanceStack.length) {
+      nextInstance = this.instanceStack.pop();
+      this.currentInstance = nextInstance;
+    }
+    this._trigger('end', currentInstance, nextInstance);
+    if (onEnd) {
+      onEnd(currentInstance, nextInstance);
+    }
+  },
+
 
   /**
    Trigger an event. Supports up to two arguments. Designed around
@@ -201,14 +265,14 @@ Backburner.prototype = {
   /*
     Join the passed method with an existing queue and execute immediately,
     if there isn't one use `Backburner#run`.
- 
+
     The join method is like the run method except that it will schedule into
     an existing queue if one already exists. In either case, the join method will
     immediately execute the passed in function and return its result.
 
-    @method join 
+    @method join
     @param {Object} target
-    @param {Function} method The method to be executed 
+    @param {Function} method The method to be executed
     @param {any} args The method arguments
     @return method result
   */
@@ -249,10 +313,10 @@ Backburner.prototype = {
   /*
     Defer the passed function to run inside the specified queue.
 
-    @method defer 
-    @param {String} queueName 
+    @method defer
+    @param {String} queueName
     @param {Object} target
-    @param {Function|String} method The method or method name to be executed 
+    @param {Function|String} method The method or method name to be executed
     @param {any} args The method arguments
     @return method result
   */

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -38,10 +38,11 @@ export default function Backburner(queueNames, options) {
     _this._runExpiredTimers();
   };
 
+  this.yieldFilter = options && options.yieldFilter || null;
   this.yieldInterval = options && options.yieldInterval || 0;
-  this.onNext = options && options.onNext;
-  this.burnCycleStartTime = 0;
   this.onBurnCycle = options && options.onBurnCycle;
+  this.onNext = options && options.onNext;
+  this.burnCycleStartTime = 0; // TODO: move to local var
 }
 
 // ms of delay before we conclude a timeout was lost
@@ -97,7 +98,13 @@ Backburner.prototype = {
     }
 
     if (!result.done){
-      setTimeout(function(){that.burnCycle()},0);
+      if (!this.yieldFilter || this.yeildFilter(currentInstance)) {
+        setTimeout(function () {
+          that.burnCycle();
+        }, 0);
+      } else {
+        that.burnCycle();
+      }
     } else {
       if (this.onBurnCycle) {
         this.onBurnCycle({

--- a/lib/backburner/deferred-action-queues.js
+++ b/lib/backburner/deferred-action-queues.js
@@ -42,6 +42,76 @@ DeferredActionQueues.prototype = {
     }
   },
 
+  queueNameIndex: 0,
+
+  next: function() {
+    var options = this.options;
+    var before = options && options.before;
+    var after = options && options.after;
+
+    var queues = this.queues;
+    var queueNames = this.queueNames;
+    var numberOfQueues = queueNames.length;
+    var queue, result, numberOfQueueItems;
+
+    /**
+     * TODO: flush() behaivior calls additional before() & after() methods in succession for each self-invoked tail-flush(true).
+     * next() does not invoke a tail-flush and also does not create a new queue "flush-segment".
+     * Is this a necessary behaivior? what is the intended use-case for before() & after()?
+     *
+     * Also, do we need to call before() & after() when there are no tasks to run in the corresponding queue?
+     *
+     * Seems we may be unnecessarily running before() & after() too often?
+     */
+
+    // find a loaded queue -- break out early if/when we run a single task
+    while (this.queueNameIndex < numberOfQueues) {
+      queue = queues[queueNames[this.queueNameIndex]];
+
+      // run before() if no tasks have been run on this queue yet
+      if (!queue.isBurning) {
+        if (before) {
+          before();
+        }
+      }
+
+      // run the first|next|last task in the queue
+      result = queue.next();
+
+      // return out of this loop with a result if a task had run
+      if (!result.done) {
+        queue.isBurning = true;
+        return result;
+      }
+      // ...otherwise continue to the next queue if the current queue has no tasks left to run
+      else {
+        if (after) {
+          after();
+        }
+        // reset our queue pointer (to check prior queues) for any new tasks when the current queue has burned down...
+        if (queue.isBurning) {
+          queue.isBurning = false;
+          this.queueNameIndex = 0;
+        }
+        // ...but go on to the next queue if the current queue was empty and had not actually run any tasks.
+        else {
+          this.queueNameIndex++;
+        }
+      }
+    }
+
+    // if you have made it here then all tasks in all queues have been burned down
+
+    // start from the begining on the next next()
+    this.queueNameIndex = 0;
+
+    // and return with a completed iterator state
+    return {
+      value: undefined,
+      done: true
+    }
+  },
+
   flush: function() {
     var queues = this.queues;
     var queueNames = this.queueNames;

--- a/lib/backburner/queue.js
+++ b/lib/backburner/queue.js
@@ -118,6 +118,73 @@ Queue.prototype = {
     }
   },
 
+  next: function() {
+    var queue = this._queue;
+    var length = queue.length;
+    var result;
+
+    if (length === 0) {
+      return {
+        value: undefined,
+        done: true
+      };
+    }
+
+    var globalOptions = this.globalOptions;
+    var options = this.options;
+    var before = options && options.before;
+    var after = options && options.after;
+    var onError = globalOptions.onError || (globalOptions.onErrorTarget &&
+                                            globalOptions.onErrorTarget[globalOptions.onErrorMethod]);
+    var target, method, args, errorRecordedForStack;
+    var invoke = onError ? this.invokeWithOnError : this.invoke;
+
+    this.targetQueues = Object.create(null);
+    var queueItems = this._queueBeingFlushed = this._queue.slice(0, 4);
+
+    // vvv before needs to be run higher up the call stack
+    // if (before) {
+    //   before();
+    // }
+
+    target                = queueItems[0];
+    method                = queueItems[1];
+    args                  = queueItems[2];
+    errorRecordedForStack = queueItems[3]; // Debugging assistance
+
+    if (isString(method)) {
+      method = target[method];
+    }
+
+    // method could have been nullified / canceled during flush
+    if (method) {
+      //
+      //    ** Attention intrepid developer **
+      //
+      //    To find out the stack of this task when it was scheduled onto
+      //    the run loop, add the following to your app.js:
+      //
+      //    Ember.run.backburner.DEBUG = true; // NOTE: This slows your app, don't leave it on in production.
+      //
+      //    Once that is in place, when you are at a breakpoint and navigate
+      //    here in the stack explorer, you can look at `errorRecordedForStack.stack`,
+      //    which will be the captured stack when this job was scheduled.
+      //
+      result = invoke(target, method, args, onError, errorRecordedForStack);
+    }
+
+    // vvv after needs to be run higher up the call stack
+    // if (after) {
+    //   after();
+    // }
+    this._queue = this._queue.slice(4);
+    this._queueBeingFlushed = undefined;
+    return {
+      value: result,
+      done: false
+    };
+  },
+
   flush: function(sync) {
     var queue = this._queue;
     var length = queue.length;


### PR DESCRIPTION
@wycats @krisselden

Based on my chat with Yehuda I am proposing to add the notion of yield into backburner.  We had originally discussed functionality around a `take()` method -- but I ended up at calling it `next()` and returning _iterator-like_ behavior.

In addition to `flush()`, one could now call `next()` on a backburner instance which would return the result of a single _next-in-bb-sequence_ task along with a `selfTime` property value. The idea is that if one were to repeatedly call `next()` on a task-loaded backburner instance, they would see behavior identical to calling `flush()`.*

I also added a top-level parameter `yeildInterval` and a rudimentary task runner `burnCycle()`.  Calling `startBurnCycle()` will start a timer and `burnCycle()` will continually call `next()` until the `yieldInterval` has elapsed or until `next().done == true`. If the iterator has not run to termination, it will resume running tasks on the next `setTimeout(fn, 0)`.  Note: this is currently implemented with requestAnimationFrame() which is too slow -- this should be changed to setTimeout().

Since this method of queue burning will add time to top level tasks -- it might make sense to enhance the internal `getYieldInterval()` result such that it would be somewhat higher when there were no display tasks left to settle in the viewport.  Or something like that.

I am working on tests now -- but I wanted to get this out for review.   The current tests all still pass.  Also, I built a version of ember using this version of backburner and ran it against the existing Linkedin Voyager web-app with no regressions.

There is obviously some code cleanup that could happen since there is a lot of overlap between `flush()` and `next()`.

I was a little disappointed to see some >1000ms Glimmer chrun on a single `next()` call.  Can that be flattened into backburner tasks?

Looking forward to some feedback.  Thanks!

\* ok: well there are some deliberate _minor_ differences here -- they are documented as TODO in the code.
