### PR TITLE
Prevent nested run loops when using `run.throttle.`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -470,7 +470,7 @@ export default class Backburner {
     }, wait);
 
     if (immediate) {
-      this.run.apply(this, args);
+      this.join.apply(this, args);
     }
 
     throttler = [target, method, timer];

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -236,3 +236,22 @@ QUnit.test('onError', function(assert) {
     throw new Error('test error');
   }, 20);
 });
+
+QUnit.test('throttle + immediate joins existing run loop instances', function(assert) {
+  assert.expect(1);
+
+  function onError(error) {
+    assert.equal('test error', error.message);
+  }
+
+  let bb = new Backburner(['errors'], {
+    onError: onError
+  });
+
+  bb.run(() => {
+    let parentInstance = bb.currentInstance;
+    bb.throttle(null, () => {
+     assert.equal(bb.currentInstance, parentInstance);
+    }, 20, true);
+  });
+});


### PR DESCRIPTION
The existing implementation would create a nested run loop if `run.throttle` were called while in an existing run loop, this updates to use `run.join` which will join the existing loop if present.
