### PR TITLE
Lock broccoli-rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "broccoli-funnel": "^1.0.6",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-plugin": "^1.2.1",
-    "broccoli-rollup": "^1.0.2",
+    "broccoli-rollup": "1.0.3",
     "do-you-even-bench": "^1.0.2",
     "ember-cli": "2.7.0",
     "glob": "^7.1.1",


### PR DESCRIPTION
Seem like `broccoli-rollup` 1.1.0 broke `npm i` here, /cc @chadhietala

<img width="1103" alt="screen shot 2017-02-17 at 7 53 22 pm" src="https://cloud.githubusercontent.com/assets/8752/23090125/c9f3123a-f54a-11e6-9cb7-281bb3f8bb2a.png">

