### PR TITLE
Rollover

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ A rewrite of the Ember.js run loop as a generic microlibrary.
 
 `Backburner#join` - Join the passed method with an existing queue and execute immediately, if there isn't one use `Backburner#run`.
 
+`Backburner#rollover` - Schedule work to be completed after yielding control back to the main thread, however as a greater priority ensure that the work is compelted before the next runloop begins.
+
 #### Alias
 
 `Backburner#schedule` - same as `defer`

--- a/lib/backburner/index.js
+++ b/lib/backburner/index.js
@@ -25,6 +25,7 @@ export default function Backburner(queueNames, options) {
     end: [],
     begin: []
   };
+  this._rollover = null;
 
   var _this = this;
   this._boundClearItems = function() {
@@ -50,6 +51,8 @@ export default function Backburner(queueNames, options) {
 
 Backburner.prototype = {
   begin: function() {
+    flushRollover(this);
+
     var options = this.options;
     var onBegin = options && options.onBegin;
     var previousInstance = this.currentInstance;
@@ -403,6 +406,13 @@ Backburner.prototype = {
     return this._setTimeout(fn, executeAt);
   },
 
+  rollover: function (fn) {
+    this._rollover = fn;
+    this._platform.setTimeout(function(){
+      flushRollover(this);
+    }, 0);
+  },
+
   _setTimeout: function (fn, executeAt) {
     if (this._timers.length === 0) {
       this._timers.push(executeAt, fn);
@@ -670,4 +680,12 @@ function findItem(target, method, collection) {
 
 function clearItems(item) {
   this._platform.clearTimeout(item[2]);
+}
+
+function flushRollover(backburner) {
+  if (backburner._rollover) {
+    var rollover = backburner._rollover;
+    backburner._rollover = null;
+    backburner.run(rollover);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "broccoli-funnel": "^1.0.6",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-plugin": "^1.2.1",
-    "broccoli-rollup": "^1.0.2",
+    "broccoli-rollup": "1.0.3",
     "do-you-even-bench": "^1.0.2",
     "ember-cli": "2.7.0",
     "glob": "^7.1.1",

--- a/tests/rollover-test.js
+++ b/tests/rollover-test.js
@@ -1,0 +1,67 @@
+import Backburner from 'backburner';
+
+var bb;
+
+module('rollover', {
+  setup: function() {
+    bb = new Backburner(['one']);
+  }
+});
+
+test('event queued in rollover happens before immediate run', function() {
+  expect(3);
+  var callNumber = 0;
+
+  var funcOne = function() {
+    equal(callNumber++, 0);
+  }
+
+  var funcTwo = function() {
+    equal(callNumber++, 1);
+  }
+
+  bb.rollover(funcOne);
+  bb.run(function() {
+    bb.schedule('one', null, funcTwo);
+  });
+
+  equal(callNumber++, 2);
+});
+
+test('event queued in rollover happens before autorun run', function() {
+  expect(3);
+  var callNumber = 0;
+
+  var funcOne = function() {
+    equal(callNumber++, 1);
+  }
+
+  var funcTwo = function() {
+    equal(callNumber++, 2);
+    start();
+  }
+
+  bb.rollover(funcOne);
+
+  equal(callNumber++, 0);
+
+  bb.schedule('one', null, funcTwo);
+
+  stop();
+});
+
+test('event queued in rollover happens', function() {
+  expect(2);
+  var callNumber = 0;
+
+  var funcOne = function() {
+    equal(callNumber++, 1);
+    start();
+  }
+
+  bb.rollover(funcOne);
+
+  equal(callNumber++, 0);
+
+  stop();
+});


### PR DESCRIPTION
This introduces an API `rollover(fn)` that permits work to be scheduled:

* With the assurance it will flush before the next runloop.
* At the latest by `setTimeout(fn, 0)`

TODO:

* [ ] Locking `broccoli-rollup` is really tracked in https://github.com/ebryn/backburner.js/pull/186
* [x] docs
* [ ] naming
* [ ] sanity check
  * [x] that `this._setTimeout(function() {}, 0)` is a bit lame
  * [ ] This current version only handles a single `rollover` batch of work, something more complex is needed for arbitrary chunking with many batches.