### PR TITLE
Don’t allow non-autoruns to be nested within autoruns.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -96,16 +96,23 @@ export default class Backburner {
     let options = this.options;
     let onBegin = options && options.onBegin;
     let previousInstance = this.currentInstance;
+    let current;
 
-    if (previousInstance) {
-      this.instanceStack.push(previousInstance);
+    if (this._autorun) {
+      current = previousInstance;
+      this._cancelAutorun();
+    } else {
+      if (previousInstance) {
+        this.instanceStack.push(previousInstance);
+      }
+      current = this.currentInstance = new DeferredActionQueues(this.queueNames, options);
+      this._trigger('begin', current, previousInstance);
     }
 
-    const current = this.currentInstance = new DeferredActionQueues(this.queueNames, options);
-    this._trigger('begin', current, previousInstance);
     if (onBegin) {
       onBegin(current, previousInstance);
     }
+
     return current;
   }
 
@@ -546,6 +553,10 @@ export default class Backburner {
     this._clearTimerTimeout();
     this._timers = [];
 
+    this._cancelAutorun();
+  }
+
+  private _cancelAutorun() {
     if (this._autorun) {
       this._platform.clearTimeout(this._autorun);
       this._autorun = null;

--- a/tests/autorun-test.ts
+++ b/tests/autorun-test.ts
@@ -21,3 +21,40 @@ QUnit.test('autorun', function(assert) {
   assert.ok(bb.currentInstance, 'The DeferredActionQueues object exists');
   assert.equal(step++, 1);
 });
+
+QUnit.test('autorun (joins next run if not yet flushed)', function(assert) {
+  let bb = new Backburner(['zomg']);
+  let order = -1;
+
+  let tasks = {
+    one: { count: 0, order: -1 },
+    two: { count: 0, order: -1 }
+  };
+
+  bb.schedule('zomg', null, () => {
+    tasks.one.count++;
+    tasks.one.order = ++order;
+  });
+
+  assert.deepEqual(tasks, {
+    one: { count: 0, order: -1 },
+    two: { count: 0, order: -1 }
+  });
+
+  bb.run(() => {
+    bb.schedule('zomg', null, () => {
+      tasks.two.count++;
+      tasks.two.order = ++order;
+    });
+
+    assert.deepEqual(tasks, {
+      one: { count: 0, order: -1 },
+      two: { count: 0, order: -1 }
+    });
+  });
+
+  assert.deepEqual(tasks, {
+    one: { count: 1, order: 0 },
+    two: { count: 1, order: 1 }
+  });
+});


### PR DESCRIPTION
If we start a new run, and an pending auto-run exists adopt it as our own, and end it when the new one would have ended.

inspired by @mixonic's https://github.com/BackburnerJS/backburner.js/commit/8b402ce59dfbae076124815f84209d77608c3242

cc @krisselden / @mixonic / @lynchbomb 