### PR TITLE
add debugging setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bower_components
 tmp/
 dist/
 npm-debug.log
+.vscode/chrome

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+        "name": "Launch localhost",
+        "type": "chrome",
+        "request": "launch",
+        "url": "http://localhost:4200/tests/",
+        "userDataDir": "${workspaceRoot}/.vscode/chrome",
+        "sourceMaps": true,
+        "webRoot": "${workspaceRoot}/dist",
+        "sourceMapPathOverrides": {
+          "../lib/*.ts": "${workspaceRoot}/lib/*.ts",
+          "../tests/*.ts": "${workspaceRoot}/tests/*.ts"
+        }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "files.exclude": {
     "**/.git": true,
     "**/.DS_Store": true,
+    ".vscode/chrome": true,
     "tmp": true,
     "config": true
   },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "0.1.0",
+  "command": "npm",
+  "isShellCommand": true,
+  "suppressTaskName": true,
+  "tasks": [
+    {
+      "taskName": "build",
+      "args": ["run", "build"],
+      "isBuildCommand": true
+    }, {
+      "taskName": "serve",
+      "args": ["run", "serve"],
+      "isBackground": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "url": "https://github.com/ebryn/backburner.js.git"
   },
   "scripts": {
-    "prepublish": "ember build --environment=production",
+    "prepublish": "npm run build",
+    "build": "ember build --environment=production",
     "test": "ember test",
     "test:server": "ember test --server",
+    "serve": "ember serve",
     "lint": "tslint lib/**/*.ts tests/**/*.ts",
     "bench": "ember build && node ./bench/index.js"
   },

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,7 +14,7 @@
   <script src="/testem.js"></script>
   <script src="loader.js"></script>
   <script src="../named-amd/backburner.js"></script>
-  <script src="tests.js"></script>
+  <script src="../named-amd/tests.js"></script>
   <script>
     require('backburner-tests');
   </script>

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         "quotemark": [true, "single", "avoid-escape"],
         "trailing-comma": [false],
-        "no-var-keyword": false,
         "object-literal-shorthand": false,
         "object-literal-sort-keys": false,
         "only-arrow-functions": [false],


### PR DESCRIPTION
sourcemaps don't work on rebuild though without patching your node_modules because of a bug in caching in rollup and the lack of the ability to disable caching in broccoli-rollup.