### PR TITLE
Swapped deprecated API support from tests

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,8 +24,6 @@ export default class Backburner {
 
   public currentInstance: DeferredActionQueues | null | undefined;
 
-  public scheduleIterable: Function;
-
   public options: any;
 
   private queueNames: string[];
@@ -305,7 +303,7 @@ export default class Backburner {
    */
   public schedule(queueName: string, method: Function);
   public schedule<T, U extends keyof T>(queueName: string, target: T, method: U, ...args);
-  public schedule(queueName: string, target: any | null, method: Function, ...args);
+  public schedule(queueName: string, target: any | null, method: any | Function, ...args);
   public schedule(queueName: string) {
     let length = arguments.length;
     let method;
@@ -340,12 +338,12 @@ export default class Backburner {
   /*
     Defer the passed iterable of functions to run inside the specified queue.
 
-    @method deferIterable
+    @method scheduleIterable
     @param {String} queueName
     @param {Iterable} an iterable of functions to execute
     @return method result
   */
-  public deferIterable(queueName: string, iterable: Function) {
+  public scheduleIterable(queueName: string, iterable: Function) {
     let stack = this.DEBUG ? new Error() : undefined;
     let _iteratorDrain = iteratorDrain;
     return this._ensureInstance().schedule(queueName, null, _iteratorDrain, [iterable], false, stack);
@@ -364,7 +362,7 @@ export default class Backburner {
    */
   public scheduleOnce(queueName: string, method: Function);
   public scheduleOnce<T, U extends keyof T>(queueName: string, target: T, method: U, ...args);
-  public scheduleOnce(queueName: string, target: any | null, method: Function, ...args);
+  public scheduleOnce(queueName: string, target: any | null, method: any | Function, ...args);
   public scheduleOnce(queueName: string /* , target, method, args */) {
     let length = arguments.length;
     let method;
@@ -761,5 +759,3 @@ export default class Backburner {
     return currentInstance;
   }
 }
-
-Backburner.prototype.scheduleIterable = Backburner.prototype.deferIterable;

--- a/tests/cancel-test.ts
+++ b/tests/cancel-test.ts
@@ -12,14 +12,14 @@ QUnit.test('null', function(assert) {
   assert.equal(bb.cancel(undefined), undefined, 'cancel an undefined timer should return undefined');
 });
 
-QUnit.test('deferOnce', function(assert) {
+QUnit.test('scheduleOnce', function(assert) {
   assert.expect(3);
 
   let bb = new Backburner(['one']);
   let functionWasCalled = false;
 
   bb.run(() => {
-    let timer = bb.deferOnce('one', () => functionWasCalled = true);
+    let timer = bb.scheduleOnce('one', () => functionWasCalled = true);
 
     assert.ok(timer, 'Timer object was returned');
     assert.ok(bb.cancel(timer), 'Cancel returned true');
@@ -39,7 +39,7 @@ QUnit.test('setTimeout', function(assert) {
   });
 
   let functionWasCalled = false;
-  let timer = bb.setTimeout(() => functionWasCalled = true);
+  let timer = bb.later(() => functionWasCalled = true);
 
   assert.ok(timer, 'Timer object was returned');
   assert.ok(bb.cancel(timer), 'Cancel returned true');
@@ -65,8 +65,8 @@ QUnit.test('setTimeout with multiple pending', function(assert) {
   let function1WasCalled = false;
   let function2WasCalled = false;
 
-  let timer1 = bb.setTimeout(() => function1WasCalled = true);
-  let timer2 = bb.setTimeout(() => function2WasCalled = true);
+  let timer1 = bb.later(() => function1WasCalled = true);
+  let timer2 = bb.later(() => function2WasCalled = true);
 
   assert.ok(timer1, 'Timer object 2 was returned');
   assert.ok(bb.cancel(timer1), 'Cancel for timer 1 returned true');
@@ -82,7 +82,7 @@ QUnit.test('setTimeout with multiple pending', function(assert) {
   }, 10);
 });
 
-QUnit.test('setTimeout and creating a new setTimeout', function(assert) {
+QUnit.test('setTimeout and creating a new later', function(assert) {
   assert.expect(7);
   let done = assert.async();
   let called = false;
@@ -94,12 +94,12 @@ QUnit.test('setTimeout and creating a new setTimeout', function(assert) {
   let function1WasCalled = false;
   let function2WasCalled = false;
 
-  let timer1 = bb.setTimeout(() => function1WasCalled = true, 0);
+  let timer1 = bb.later(() => function1WasCalled = true, 0);
 
   assert.ok(timer1, 'Timer object 2 was returned');
   assert.ok(bb.cancel(timer1), 'Cancel for timer 1 returned true');
 
-  let timer2 = bb.setTimeout(() => function2WasCalled = true, 1);
+  let timer2 = bb.later(() => function2WasCalled = true, 1);
 
   assert.ok(timer2, 'Timer object 2 was returned');
   assert.ok(!called, 'onBegin was not called');
@@ -116,7 +116,7 @@ QUnit.test('cancelTimers', function(assert) {
   let bb = new Backburner(['one']);
   let functionWasCalled = false;
 
-  let timer = bb.setTimeout(() => functionWasCalled = true);
+  let timer = bb.later(() => functionWasCalled = true);
 
   assert.ok(timer, 'Timer object was returned');
   assert.ok(bb.hasTimers(), 'bb has scheduled timer');
@@ -134,8 +134,8 @@ QUnit.test('cancel during flush', function(assert) {
   let functionWasCalled = false;
 
   bb.run(() => {
-    let timer1 = bb.deferOnce('one', () => bb.cancel(timer2));
-    let timer2 = bb.deferOnce('one', () => functionWasCalled = true);
+    let timer1 = bb.scheduleOnce('one', () => bb.cancel(timer2));
+    let timer2 = bb.scheduleOnce('one', () => functionWasCalled = true);
   });
 
   assert.ok(!functionWasCalled, 'function was not called');

--- a/tests/configurable-timeout-test.ts
+++ b/tests/configurable-timeout-test.ts
@@ -18,7 +18,7 @@ QUnit.test('We can configure a custom platform', function(assert) {
   assert.ok(bb.options._platform.isFakePlatform, 'We can pass in a custom platform');
 });
 
-QUnit.test('We can use a custom setTimeout', function(assert) {
+QUnit.test('We can use a custom later', function(assert) {
   assert.expect(2);
   let done = assert.async();
 
@@ -36,9 +36,9 @@ QUnit.test('We can use a custom setTimeout', function(assert) {
     }
   });
 
-  bb.deferOnce('one', () => {
+  bb.scheduleOnce('one', () => {
     assert.ok(bb.options._platform.isFakePlatform, 'we are using the fake platform');
-    assert.ok(customTimeoutWasUsed , 'custom setTimeout was used');
+    assert.ok(customTimeoutWasUsed , 'custom later was used');
     done();
   });
 });
@@ -67,11 +67,11 @@ QUnit.test('We can use a custom clearTimeout', function(assert) {
     }
   });
 
-  bb.deferOnce('one', () => functionWasCalled = true);
+  bb.scheduleOnce('one', () => functionWasCalled = true);
   bb.cancelTimers();
 
   bb.run(() => {
-    bb.deferOnce('one', () => {
+    bb.scheduleOnce('one', () => {
       assert.ok(!functionWasCalled, 'function was not called');
       assert.ok(customClearTimeoutWasUsed, 'custom clearTimeout was used');
     });

--- a/tests/debug-test.ts
+++ b/tests/debug-test.ts
@@ -5,13 +5,13 @@ QUnit.module('tests/debug');
 QUnit.test('DEBUG flag enables stack tagging', function(assert) {
   let bb = new Backburner(['one']);
 
-  bb.defer('one', () => {});
+  bb.schedule('one', () => {});
 
   assert.ok(bb.currentInstance && !bb.currentInstance.queues.one._queue[3], 'No stack is recorded');
 
   bb.DEBUG = true;
 
-  bb.defer('one', () => {});
+  bb.schedule('one', () => {});
 
   if (new Error().stack) { // workaround for CLI runner :(
     assert.expect(4);
@@ -27,7 +27,7 @@ QUnit.test('DEBUG flag enables stack tagging', function(assert) {
     bb.DEBUG = true;
 
     bb.run(() => {
-      bb.defer('errors', () => {
+      bb.schedule('errors', () => {
         throw new Error('message!');
       });
     });

--- a/tests/defer-iterable-test.ts
+++ b/tests/defer-iterable-test.ts
@@ -51,7 +51,7 @@ QUnit.test('deferIterable', function(assert) {
   let iterator = () => new Iterator([task1, task2, task3]);
 
   bb.run(() => {
-    bb.deferIterable('zomg', iterator);
+    bb.scheduleIterable('zomg', iterator);
 
     assert.deepEqual(tasks, {
       one:   { count: 0,  order: -1 },
@@ -65,9 +65,4 @@ QUnit.test('deferIterable', function(assert) {
     two:   { count: 1,  order: 1 },
     three: { count: 1,  order: 2 }
   });
-});
-
-QUnit.test('deferIterable aliased to scheduleIterable', function(assert) {
-  let bb = new Backburner(['zomg']);
-  assert.equal(bb.deferIterable, bb.scheduleIterable);
 });

--- a/tests/defer-once-test.ts
+++ b/tests/defer-once-test.ts
@@ -9,7 +9,7 @@ QUnit.test('when passed a function', function(assert) {
   let functionWasCalled = false;
 
   bb.run(() => {
-    bb.deferOnce('one', () => {
+    bb.scheduleOnce('one', () => {
       functionWasCalled = true;
     });
   });
@@ -24,7 +24,7 @@ QUnit.test('when passed a target and method', function(assert) {
   let functionWasCalled = false;
 
   bb.run(() => {
-    bb.deferOnce('one', {zomg: 'hi'}, function() {
+    bb.scheduleOnce('one', {zomg: 'hi'}, function() {
       assert.equal(this.zomg, 'hi', 'the target was properly set');
       functionWasCalled = true;
     });
@@ -46,7 +46,7 @@ QUnit.test('when passed a target and method name', function(assert) {
     }
   };
 
-  bb.run(() => bb.deferOnce('one', targetObject, 'checkFunction'));
+  bb.run(() => bb.scheduleOnce('one', targetObject, 'checkFunction'));
 
   assert.ok(functionWasCalled, 'function was called');
 });
@@ -62,7 +62,7 @@ QUnit.test('throws when passed a null method', function(assert) {
     onError
   });
 
-  bb.run(() => bb.deferOnce('deferErrors', {zomg: 'hi'}, null));
+  bb.run(() => bb.scheduleOnce('deferErrors', {zomg: 'hi'}, null));
 });
 
 QUnit.test('throws when passed an undefined method', function(assert) {
@@ -100,7 +100,7 @@ QUnit.test('when passed a target, method, and arguments', function(assert) {
   let functionWasCalled = false;
 
   bb.run(() => {
-    bb.deferOnce('one', {zomg: 'hi'}, function(a, b, c) {
+    bb.scheduleOnce('one', {zomg: 'hi'}, function(a, b, c) {
       assert.equal(this.zomg, 'hi', 'the target was properly set');
       assert.equal(a, 1, 'the first arguments was passed in');
       assert.equal(b, 2, 'the second arguments was passed in');
@@ -126,8 +126,8 @@ QUnit.test('when passed same function twice', function(assert) {
   }
 
   bb.run(() => {
-    bb.deferOnce('one', deferMethod);
-    bb.deferOnce('one', deferMethod);
+    bb.scheduleOnce('one', deferMethod);
+    bb.scheduleOnce('one', deferMethod);
   });
 
   assert.ok(functionWasCalled, 'function was called only once');
@@ -150,8 +150,8 @@ QUnit.test('when passed same function twice with same target', function(assert) 
   let argObj = {first: 1};
 
   bb.run(() => {
-    bb.deferOnce('one', argObj, deferMethod);
-    bb.deferOnce('one', argObj, deferMethod);
+    bb.scheduleOnce('one', argObj, deferMethod);
+    bb.scheduleOnce('one', argObj, deferMethod);
   });
 
   assert.ok(functionWasCalled, 'function was called only once');
@@ -169,8 +169,8 @@ QUnit.test('when passed same function twice with different targets', function(as
   }
 
   bb.run(() => {
-    bb.deferOnce('one', {first: 1}, deferMethod);
-    bb.deferOnce('one', {first: 1}, deferMethod);
+    bb.scheduleOnce('one', {first: 1}, deferMethod);
+    bb.scheduleOnce('one', {first: 1}, deferMethod);
   });
 
   assert.equal(i, 2, 'function was called twice');
@@ -192,8 +192,8 @@ QUnit.test('when passed same function twice with same arguments and same target'
   let argObj = {first: 1};
 
   bb.run(() => {
-    bb.deferOnce('one', argObj, deferMethod, 1, 2);
-    bb.deferOnce('one', argObj, deferMethod, 1, 2);
+    bb.scheduleOnce('one', argObj, deferMethod, 1, 2);
+    bb.scheduleOnce('one', argObj, deferMethod, 1, 2);
   });
 
   assert.equal(i, 1, 'function was called once');
@@ -215,8 +215,8 @@ QUnit.test('when passed same function twice with same target and different argum
   let argObj = {first: 1};
 
   bb.run(() => {
-    bb.deferOnce('one', argObj, deferMethod, 1, 2);
-    bb.deferOnce('one', argObj, deferMethod, 3, 2);
+    bb.scheduleOnce('one', argObj, deferMethod, 1, 2);
+    bb.scheduleOnce('one', argObj, deferMethod, 3, 2);
   });
 
   assert.equal(i, 1, 'function was called once');
@@ -242,8 +242,8 @@ QUnit.test('when passed same function twice with different target and different 
   let argObj = {first: 1};
 
   bb.run(() => {
-    bb.deferOnce('one', {first: 1}, deferMethod, 1, 2);
-    bb.deferOnce('one', {first: 1}, deferMethod, 3, 2);
+    bb.scheduleOnce('one', {first: 1}, deferMethod, 1, 2);
+    bb.scheduleOnce('one', {first: 1}, deferMethod, 3, 2);
   });
 
   assert.equal(i, 2, 'function was called twice');
@@ -262,14 +262,14 @@ QUnit.test('when passed same function with same target after already triggering 
   }
 
   function scheduleMethod() {
-    bb.deferOnce('one', argObj, deferMethod, 2);
+    bb.scheduleOnce('one', argObj, deferMethod, 2);
   }
 
   let argObj = {first: 1, GUID_KEY: '1'};
 
   bb.run(() => {
-    bb.deferOnce('one', argObj, deferMethod, 1);
-    bb.deferOnce('two', argObj, scheduleMethod);
+    bb.scheduleOnce('one', argObj, deferMethod, 1);
+    bb.scheduleOnce('two', argObj, scheduleMethod);
   });
 
   assert.equal(i, 2, 'function was called twice');
@@ -285,7 +285,7 @@ QUnit.test('onError', function(assert) {
   let bb = new Backburner(['errors'], { onError });
 
   bb.run(() => {
-    bb.deferOnce('errors', () => {
+    bb.scheduleOnce('errors', () => {
       throw new Error('QUnit.test error');
     });
   });

--- a/tests/defer-test.ts
+++ b/tests/defer-test.ts
@@ -14,7 +14,7 @@ QUnit.test('when passed a function', function(assert) {
   let functionWasCalled = false;
 
   bb.run(() => {
-    bb.defer('one', () => functionWasCalled = true);
+    bb.schedule('one', () => functionWasCalled = true);
   });
 
   assert.ok(functionWasCalled, 'function was called');
@@ -27,7 +27,7 @@ QUnit.test('when passed a target and method', function(assert) {
   let functionWasCalled = false;
 
   bb.run(() => {
-    bb.defer('one', { zomg: 'hi' }, function() {
+    bb.schedule('one', { zomg: 'hi' }, function() {
       assert.equal(this.zomg, 'hi', 'the target was properly set');
       functionWasCalled = true;
     });
@@ -49,7 +49,7 @@ QUnit.test('when passed a target and method name', function(assert) {
     }
   };
 
-  bb.run(() => bb.defer('one', targetObject, 'checkFunction'));
+  bb.run(() => bb.schedule('one', targetObject, 'checkFunction'));
 
   assert.ok(functionWasCalled, 'function was called');
 });
@@ -65,7 +65,7 @@ QUnit.test('throws when passed a null method', function(assert) {
     onError
   });
 
-  bb.run(() => bb.defer('deferErrors', { zomg: 'hi' }, null));
+  bb.run(() => bb.schedule('deferErrors', { zomg: 'hi' }, null));
 });
 
 QUnit.test('throws when passed an undefined method', function(assert) {
@@ -79,7 +79,7 @@ QUnit.test('throws when passed an undefined method', function(assert) {
     onError
   });
 
-  bb.run(() => bb.defer('deferErrors', { zomg: 'hi' }, undefined));
+  bb.run(() => bb.schedule('deferErrors', { zomg: 'hi' }, undefined));
 });
 
 QUnit.test('throws when passed an method name that does not exists on the target', function(assert) {
@@ -93,7 +93,7 @@ QUnit.test('throws when passed an method name that does not exists on the target
     onError
   });
 
-  bb.run(() => bb.defer('deferErrors', { zomg: 'hi' }, 'checkFunction'));
+  bb.run(() => bb.schedule('deferErrors', { zomg: 'hi' }, 'checkFunction'));
 });
 
 QUnit.test('when passed a target, method, and arguments', function(assert) {
@@ -103,7 +103,7 @@ QUnit.test('when passed a target, method, and arguments', function(assert) {
   let functionWasCalled = false;
 
   bb.run(() => {
-    bb.defer('one', { zomg: 'hi' }, function(a, b, c) {
+    bb.schedule('one', { zomg: 'hi' }, function(a, b, c) {
       assert.equal(this.zomg, 'hi', 'the target was properly set');
       assert.equal(a, 1, 'the first arguments was passed in');
       assert.equal(b, 2, 'the second arguments was passed in');
@@ -126,8 +126,8 @@ QUnit.test('when passed same function twice', function(assert) {
   }
 
   bb.run(() => {
-    bb.defer('one', deferMethod);
-    bb.defer('one', deferMethod);
+    bb.schedule('one', deferMethod);
+    bb.schedule('one', deferMethod);
   });
 
   assert.equal(i, 2, 'function was called twice');
@@ -145,8 +145,8 @@ QUnit.test('when passed same function twice with arguments', function(assert) {
   }
 
   bb.run(() => {
-    bb.defer('one', argObj, deferMethod);
-    bb.defer('one', argObj, deferMethod);
+    bb.schedule('one', argObj, deferMethod);
+    bb.schedule('one', argObj, deferMethod);
   });
 });
 
@@ -166,8 +166,8 @@ QUnit.test('when passed same function twice with same arguments and same target'
   let argObj = { first: 1 };
 
   bb.run(() => {
-    bb.defer('one', argObj, deferMethod, 1, 2);
-    bb.defer('one', argObj, deferMethod, 1, 2);
+    bb.schedule('one', argObj, deferMethod, 1, 2);
+    bb.schedule('one', argObj, deferMethod, 1, 2);
   });
 
   assert.equal(i, 2, 'function was called twice');
@@ -193,8 +193,8 @@ QUnit.test('when passed same function twice with same target and different argum
   let argObj = { first: 1 };
 
   bb.run(() => {
-    bb.defer('one', argObj, deferMethod, 1, 2);
-    bb.defer('one', argObj, deferMethod, 3, 2);
+    bb.schedule('one', argObj, deferMethod, 1, 2);
+    bb.schedule('one', argObj, deferMethod, 3, 2);
   });
 
   assert.equal(i, 2, 'function was called twice');
@@ -220,8 +220,8 @@ QUnit.test('when passed same function twice with different target and different 
   let argObj = {first: 1};
 
   bb.run(() => {
-    bb.defer('one', { first: 1 }, deferMethod, 1, 2);
-    bb.defer('one', { first: 1 }, deferMethod, 3, 2);
+    bb.schedule('one', { first: 1 }, deferMethod, 1, 2);
+    bb.schedule('one', { first: 1 }, deferMethod, 3, 2);
   });
 
   assert.equal(i, 2, 'function was called twice');
@@ -239,7 +239,7 @@ QUnit.test('onError', function(assert) {
   });
 
   bb.run(() => {
-    bb.defer('errors', () => {
+    bb.schedule('errors', () => {
       throw new Error('QUnit.test error');
     });
   });

--- a/tests/run-test.ts
+++ b/tests/run-test.ts
@@ -55,24 +55,24 @@ QUnit.test('nesting run loops preserves the stack', function(assert) {
   let outerAfterFunctionWasCalled = false;
 
   bb.run(function () {
-    bb.defer('one', () => {
+    bb.schedule('one', () => {
       outerBeforeFunctionWasCalled = true;
     });
 
     bb.run(function () {
-      bb.defer('one', () => {
+      bb.schedule('one', () => {
         middleBeforeFunctionWasCalled = true;
       });
 
       bb.run(function () {
-        bb.defer('one', function () {
+        bb.schedule('one', function () {
           innerFunctionWasCalled = true;
         });
         assert.ok(!innerFunctionWasCalled, 'function is deferred');
       });
       assert.ok(innerFunctionWasCalled, 'function is called');
 
-      bb.defer('one', function () {
+      bb.schedule('one', function () {
         middleAfterFunctionWasCalled = true;
       });
 
@@ -83,7 +83,7 @@ QUnit.test('nesting run loops preserves the stack', function(assert) {
     assert.ok(middleBeforeFunctionWasCalled, 'function is called');
     assert.ok(middleAfterFunctionWasCalled, 'function is called');
 
-    bb.defer('one', function () {
+    bb.schedule('one', function () {
       outerAfterFunctionWasCalled = true;
     });
 

--- a/tests/set-timeout-test.ts
+++ b/tests/set-timeout-test.ts
@@ -10,7 +10,7 @@ QUnit.module('tests/set-timeout-test', {
   }
 });
 
-QUnit.test('setTimeout', function(assert) {
+QUnit.test('later', function(assert) {
   assert.expect(6);
 
   let bb = new Backburner(['one']);
@@ -23,12 +23,12 @@ QUnit.test('setTimeout', function(assert) {
   let now = +new Date();
   Date.prototype.valueOf = function() { return now; };
 
-  bb.setTimeout(null, () => {
+  bb.later(null, () => {
     instance = bb.currentInstance;
     assert.equal(step++, 0);
   }, 10);
 
-  bb.setTimeout(null, () => {
+  bb.later(null, () => {
     assert.equal(step++, 1);
     assert.equal(instance, bb.currentInstance, 'same instance');
   }, 10);
@@ -39,10 +39,10 @@ QUnit.test('setTimeout', function(assert) {
   // 0ms
   while ((+ new Date()) <= now + 10) {};
 
-  bb.setTimeout(null, () => {
+  bb.later(null, () => {
     assert.equal(step++, 2);
 
-    bb.setTimeout(null, () => {
+    bb.later(null, () => {
       assert.equal(step++, 3);
       assert.ok(true, 'Another later will execute correctly');
       done();
@@ -50,7 +50,7 @@ QUnit.test('setTimeout', function(assert) {
   }, 20);
 });
 
-QUnit.test('setTimeout can continue when `Date.now` is monkey-patched', function(assert) {
+QUnit.test('later can continue when `Date.now` is monkey-patched', function(assert) {
   assert.expect(1);
 
   let arbitraryTime = +new Date();
@@ -59,14 +59,14 @@ QUnit.test('setTimeout can continue when `Date.now` is monkey-patched', function
 
   Date.now = function() { return arbitraryTime; };
 
-  bb.setTimeout(() => {
+  bb.later(() => {
     assert.ok(true);
     done();
   }, 1);
 });
 
 let bb;
-QUnit.module('setTimeout arguments / arity', {
+QUnit.module('later arguments / arity', {
   beforeEach() {
     bb = new Backburner(['one']);
   },
@@ -80,7 +80,7 @@ QUnit.test('[callback]', function(assert) {
 
   let done = assert.async();
 
-  bb.setTimeout(function() {
+  bb.later(function() {
     assert.equal(arguments.length, 0);
     assert.ok(true, 'was called');
     done();
@@ -91,7 +91,7 @@ QUnit.test('[callback, undefined]', function(assert) {
   assert.expect(2);
   let done = assert.async();
 
-  bb.setTimeout(function() {
+  bb.later(function() {
     assert.equal(arguments.length, 1);
     assert.ok(true, 'was called');
     done();
@@ -102,7 +102,7 @@ QUnit.test('[null, callback, undefined]', function(assert) {
   assert.expect(2);
   let done = assert.async();
 
-  bb.setTimeout(null, function() {
+  bb.later(null, function() {
     assert.equal(arguments.length, 0);
     assert.ok(true, 'was called');
     done();
@@ -113,7 +113,7 @@ QUnit.test('[null, callback, undefined]', function(assert) {
   assert.expect(2);
   let done = assert.async();
 
-  bb.setTimeout(null, function() {
+  bb.later(null, function() {
     assert.equal(arguments.length, 1);
     assert.ok(true, 'was called');
     done();
@@ -125,7 +125,7 @@ QUnit.test('[null, callback, null]', function(assert) {
 
   let done = assert.async();
 
-  bb.setTimeout(null, function() {
+  bb.later(null, function() {
     assert.equal(arguments.length, 1);
     assert.equal(arguments[0], null);
     assert.ok(true, 'was called');
@@ -138,7 +138,7 @@ QUnit.test('[callback, string, string, string]', function(assert) {
 
   let done = assert.async();
 
-  bb.setTimeout(function() {
+  bb.later(function() {
     assert.equal(arguments.length, 3);
     assert.equal(arguments[0], 'a');
     assert.equal(arguments[1], 'b');
@@ -153,7 +153,7 @@ QUnit.test('[null, callback, string, string, string]', function(assert) {
 
   let done = assert.async();
 
-  bb.setTimeout(null, function() {
+  bb.later(null, function() {
     assert.equal(arguments.length, 3);
     assert.equal(arguments[0], 'a');
     assert.equal(arguments[1], 'b');
@@ -166,7 +166,7 @@ QUnit.test('[null, callback, string, string, string]', function(assert) {
 QUnit.test('[null, callback, string, string, string, number]', function(assert) {
   assert.expect(5);
   let done = assert.async();
-  bb.setTimeout(null, function() {
+  bb.later(null, function() {
     assert.equal(arguments.length, 3);
     assert.equal(arguments[0], 'a');
     assert.equal(arguments[1], 'b');
@@ -179,7 +179,7 @@ QUnit.test('[null, callback, string, string, string, number]', function(assert) 
 QUnit.test('[null, callback, string, string, string, numericString]', function(assert) {
   assert.expect(5);
   let done = assert.async();
-  bb.setTimeout(null, function() {
+  bb.later(null, function() {
     assert.equal(arguments.length, 3);
     assert.equal(arguments[0], 'a');
     assert.equal(arguments[1], 'b');
@@ -192,7 +192,7 @@ QUnit.test('[null, callback, string, string, string, numericString]', function(a
 QUnit.test('[obj, string]', function(assert) {
   assert.expect(1);
   let done = assert.async();
-  bb.setTimeout({
+  bb.later({
     bro() {
       assert.ok(true, 'was called');
       done();
@@ -203,7 +203,7 @@ QUnit.test('[obj, string]', function(assert) {
 QUnit.test('[obj, string, value]', function(assert) {
   assert.expect(3);
   let done = assert.async();
-  bb.setTimeout({
+  bb.later({
     bro() {
       assert.equal(arguments.length, 1);
       assert.equal(arguments[0], 'value');
@@ -215,7 +215,7 @@ QUnit.test('[obj, string, value]', function(assert) {
 
 QUnit.test('[obj, string, value, number]', function(assert) {
   let done = assert.async();
-  bb.setTimeout({
+  bb.later({
     bro() {
       assert.equal(arguments.length, 1);
       assert.equal(arguments[0], 'value');
@@ -227,7 +227,7 @@ QUnit.test('[obj, string, value, number]', function(assert) {
 
 QUnit.test('[obj, string, value, numericString]', function(assert) {
   let done = assert.async();
-  bb.setTimeout({
+  bb.later({
     bro() {
       assert.equal(arguments.length, 1);
       assert.equal(arguments[0], 'value');
@@ -249,10 +249,10 @@ QUnit.test('onError', function(assert) {
 
   bb = new Backburner(['errors'], { onError });
 
-  bb.setTimeout(() => { throw new Error('test error'); }, 1);
+  bb.later(() => { throw new Error('test error'); }, 1);
 });
 
-QUnit.test('setTimeout doesn\'t trigger twice with earlier setTimeout', function(assert) {
+QUnit.test('later doesn\'t trigger twice with earlier later', function(assert) {
   assert.expect(3);
 
   bb = new Backburner(['one']);
@@ -268,8 +268,8 @@ QUnit.test('setTimeout doesn\'t trigger twice with earlier setTimeout', function
     oldRun.apply(bb, arguments);
   };
 
-  bb.setTimeout(() => called1++, 50);
-  bb.setTimeout(() => called2++, 10);
+  bb.later(() => called1++, 50);
+  bb.later(() => called2++, 10);
 
   setTimeout(() => {
     assert.equal(called1, 1, 'timeout 1 was called once');
@@ -279,7 +279,7 @@ QUnit.test('setTimeout doesn\'t trigger twice with earlier setTimeout', function
   }, 100);
 });
 
-QUnit.test('setTimeout with two Backburner instances', function(assert) {
+QUnit.test('later with two Backburner instances', function(assert) {
   assert.expect(8);
 
   let steps = 0;
@@ -297,11 +297,11 @@ QUnit.test('setTimeout with two Backburner instances', function(assert) {
 
   assert.equal(++steps, 1);
 
-  bb1.setTimeout(() => assert.equal(++steps, 5), 10);
+  bb1.later(() => assert.equal(++steps, 5), 10);
 
   assert.equal(++steps, 2);
 
-  bb2.setTimeout(() => assert.equal(++steps, 7), 10);
+  bb2.later(() => assert.equal(++steps, 7), 10);
 
   assert.equal(++steps, 3);
 
@@ -318,13 +318,13 @@ QUnit.test('expired timeout doesn\'t hang when setting a new timeout', function(
   let called2At = 0;
   let done = assert.async();
 
-  bb.setTimeout(() => called1At = Date.now(), 1);
+  bb.later(() => called1At = Date.now(), 1);
 
   // Block JS to simulate https://github.com/ebryn/backburner.js/issues/135
   let waitUntil = Date.now() + 5;
   while (Date.now() < waitUntil) { }
 
-  bb.setTimeout(() => called2At = Date.now(), 50);
+  bb.later(() => called2At = Date.now(), 50);
 
   setTimeout(() => {
     assert.ok(called1At !== 0, 'timeout 1 was called');
@@ -341,9 +341,9 @@ QUnit.test('NaN timeout doesn\'t hang other timeouts', function(assert) {
   let called1At = 0;
   let called2At = 0;
 
-  bb.setTimeout(() => called1At = Date.now(), 1);
-  bb.setTimeout(() => {}, NaN);
-  bb.setTimeout(() => called2At = Date.now(), 10);
+  bb.later(() => called1At = Date.now(), 1);
+  bb.later(() => {}, NaN);
+  bb.later(() => called2At = Date.now(), 10);
 
   setTimeout(() => {
     assert.ok(called1At !== 0, 'timeout 1 was called');


### PR DESCRIPTION
Since we have settled on `schedule[x]` as the default API and deprecated `defer[x]` as such, i've removed support for `deferIterable` for `scheduleIterable` before the API goes mainstream. 

@krisselden comment?