### PR TITLE
Allow for peekGuid to be passed in options.

### DIFF
--- a/lib/backburner/queue.ts
+++ b/lib/backburner/queue.ts
@@ -32,13 +32,10 @@ export default class Queue {
   }
 
   public pushUnique(target, method, args, stack) {
-    let KEY = this.globalOptions.GUID_KEY;
+    let guid = this.guidForTarget(target);
 
-    if (target && KEY) {
-      let guid = target[KEY];
-      if (guid) {
-        return this.pushUniqueWithGuid(guid, target, method, args, stack);
-      }
+    if (guid) {
+      return this.pushUniqueWithGuid(guid, target, method, args, stack);
     }
 
     this.pushUniqueWithoutGuid(target, method, args, stack);
@@ -139,10 +136,10 @@ export default class Queue {
     let i;
     let l;
     let { target, method }  = actionToCancel;
-    let GUID_KEY = this.globalOptions.GUID_KEY;
 
-    if (GUID_KEY && this.targetQueues && target) {
-      let targetQueue = this.targetQueues[target[GUID_KEY]];
+    if (this.targetQueues && target) {
+      let guid = this.guidForTarget(target);
+      let targetQueue = this.targetQueues[guid];
 
       if (targetQueue) {
         for (i = 0, l = targetQueue.length; i < l; i++) {
@@ -183,6 +180,20 @@ export default class Queue {
         queue[i + 1] = null;
         return true;
       }
+    }
+  }
+
+  private guidForTarget(target) {
+    if (!target) { return; }
+
+    let peekGuid = this.globalOptions.peekGuid;
+    if (peekGuid) {
+      return peekGuid(target);
+    }
+
+    let KEY = this.globalOptions.GUID_KEY;
+    if (KEY) {
+      return target[KEY];
     }
   }
 

--- a/tests/cancel-test.ts
+++ b/tests/cancel-test.ts
@@ -227,3 +227,90 @@ QUnit.test('with GUID_KEY no target', function(assert) {
 
   assert.equal(wasCalled, 1);
 });
+
+QUnit.test('with peekGuid and target', function(assert) {
+  assert.expect(3);
+
+  let obj = {};
+
+  let bb = new Backburner(['action'], {
+    peekGuid(obj2) {
+      if (obj === obj2) { return 1; }
+    }
+  });
+
+  let wasCalled = 0;
+
+  function fn() {
+    wasCalled++;
+  }
+
+  bb.run(() => {
+    let timer = bb.scheduleOnce('action', obj, fn);
+
+    assert.equal(wasCalled, 0);
+
+    bb.cancel(timer);
+    bb.scheduleOnce('action', obj, fn);
+
+    assert.equal(wasCalled, 0);
+  });
+
+  assert.equal(wasCalled, 1);
+});
+
+QUnit.test('with peekGuid and a target without guid', function(assert) {
+  assert.expect(3);
+
+  let obj = { };
+
+  let bb = new Backburner(['action'], {
+    peekGuid() { }
+  });
+
+  let wasCalled = 0;
+
+  function fn () {
+    wasCalled++;
+  }
+
+  bb.run(() => {
+    let timer = bb.scheduleOnce('action', obj, fn);
+
+    assert.equal(wasCalled, 0);
+
+    bb.cancel(timer);
+    bb.scheduleOnce('action', obj, fn);
+
+    assert.equal(wasCalled, 0);
+  });
+
+  assert.equal(wasCalled, 1);
+});
+
+QUnit.test('with peekGuid no target', function(assert) {
+  assert.expect(3);
+
+  let bb = new Backburner(['action'], {
+    peekGuid() { }
+  });
+
+  let wasCalled = 0;
+
+  function fn () {
+    wasCalled++;
+  }
+
+  bb.run(() => {
+    let timer = bb.scheduleOnce('action', fn);
+
+    assert.equal(wasCalled, 0);
+
+    bb.cancel(timer);
+    bb.scheduleOnce('action', fn);
+
+    assert.equal(wasCalled, 0);
+  });
+
+  assert.equal(wasCalled, 1);
+});

--- a/tests/defer-once-test.ts
+++ b/tests/defer-once-test.ts
@@ -275,6 +275,36 @@ QUnit.test('when passed same function with same target after already triggering 
   assert.equal(i, 2, 'function was called twice');
 });
 
+QUnit.test('when passed same function with same target after already triggering in current loop (peekGuid)', function(assert) {
+  assert.expect(5);
+
+  let argObj = {first: 1};
+  let bb = new Backburner(['one', 'two'], {
+    peekGuid(obj) {
+      if (argObj === obj) { return '1'; }
+    }
+  });
+
+  let i = 0;
+
+  function deferMethod(a) {
+    i++;
+    assert.equal(a, i, 'Correct argument is set');
+    assert.equal(this['first'], 1, 'the target property was set');
+  }
+
+  function scheduleMethod() {
+    bb.scheduleOnce('one', argObj, deferMethod, 2);
+  }
+
+  bb.run(() => {
+    bb.scheduleOnce('one', argObj, deferMethod, 1);
+    bb.scheduleOnce('two', argObj, scheduleMethod);
+  });
+
+  assert.equal(i, 2, 'function was called twice');
+});
+
 QUnit.test('onError', function(assert) {
   assert.expect(1);
 

--- a/tests/queue-push-unique-test.ts
+++ b/tests/queue-push-unique-test.ts
@@ -185,3 +185,151 @@ QUnit.test('pushUnique: 1 target, 2 different methods, second one called twice (
 
   assert.deepEqual(target1barWasCalled.length, 1, 'expected: target 1.bar to be called only once');
 });
+
+QUnit.test('pushUnique: 2 different targets (peekGuid)', function(assert) {
+  let guidIndexer = [];
+  let queue = new Queue('foo', {}, {
+    peekGuid(obj) {
+      let guid = guidIndexer.indexOf(obj);
+      if (guid === -1) {
+        return null;
+      }
+
+      return guid;
+    }
+  });
+
+  let target1fooWasCalled: string[][] = [];
+  let target2fooWasCalled: string[][] = [];
+  let target1 = {
+    foo: function() {
+      target1fooWasCalled.push(slice.call(arguments));
+    }
+  };
+  guidIndexer.push(target1);
+
+  let target2 = {
+    foo: function() {
+      target2fooWasCalled.push(slice.call(arguments));
+    }
+  };
+  guidIndexer.push(target2);
+
+  queue.pushUnique(target1, target1.foo, ['a']);
+  queue.pushUnique(target2, target2.foo, ['b']);
+
+  assert.deepEqual(target1fooWasCalled, []);
+  assert.deepEqual(target2fooWasCalled, []);
+
+  queue.flush();
+
+  assert.deepEqual(target1fooWasCalled.length, 1, 'expected: target 1.foo to be called only once');
+  assert.deepEqual(target1fooWasCalled[0], ['a']);
+  assert.deepEqual(target2fooWasCalled.length, 1, 'expected: target 2.foo to be called only once');
+  assert.deepEqual(target2fooWasCalled[0], ['b']);
+});
+
+QUnit.test('pushUnique: 1 target, 2 different methods (peekGuid)', function(assert) {
+  let guidIndexer = [];
+  let queue = new Queue('foo', {}, {
+    peekGuid(obj) {
+      let guid = guidIndexer.indexOf(obj);
+      if (guid === -1) {
+        return null;
+      }
+
+      return guid;
+    }
+
+  });
+  let target1fooWasCalled: string[][] = [];
+  let target1barWasCalled: string[][] = [];
+  let target1 = {
+    foo: function() {
+      target1fooWasCalled.push(slice.call(arguments));
+    },
+    bar: function() {
+      target1barWasCalled.push(slice.call(arguments));
+    }
+  };
+  guidIndexer.push(target1);
+
+  queue.pushUnique(target1, target1.foo, ['a']);
+  queue.pushUnique(target1, target1.bar, ['b']);
+
+  assert.deepEqual(target1fooWasCalled, []);
+  assert.deepEqual(target1barWasCalled, []);
+
+  queue.flush();
+
+  assert.deepEqual(target1fooWasCalled.length, 1, 'expected: target 1.foo to be called only once');
+  assert.deepEqual(target1fooWasCalled[0], ['a']);
+  assert.deepEqual(target1barWasCalled.length, 1, 'expected: target 1.bar to be called only once');
+  assert.deepEqual(target1barWasCalled[0], ['b']);
+});
+
+QUnit.test('pushUnique: 1 target, 1 different methods called twice (peekGuid)', function(assert) {
+  let guidIndexer = [];
+  let queue = new Queue('foo', {}, {
+    peekGuid(obj) {
+      let guid = guidIndexer.indexOf(obj);
+      if (guid === -1) {
+        return null;
+      }
+
+      return guid;
+    }
+
+  });
+  let target1fooWasCalled: string[][] = [];
+  let target1 = {
+    foo: function() {
+      target1fooWasCalled.push(slice.call(arguments));
+    }
+  };
+  guidIndexer.push(target1);
+
+  queue.pushUnique(target1, target1.foo, ['a']);
+  queue.pushUnique(target1, target1.foo, ['b']);
+
+  assert.deepEqual(target1fooWasCalled, []);
+
+  queue.flush();
+
+  assert.deepEqual(target1fooWasCalled.length, 1, 'expected: target 1.foo to be called only once');
+  assert.deepEqual(target1fooWasCalled[0], ['b']);
+});
+
+QUnit.test('pushUnique: 1 target, 2 different methods, second one called twice (peekGuid)', function(assert) {
+  let guidIndexer = [];
+  let queue = new Queue('foo', {}, {
+    peekGuid(obj) {
+      let guid = guidIndexer.indexOf(obj);
+      if (guid === -1) {
+        return null;
+      }
+
+      return guid;
+    }
+  });
+
+  let target1barWasCalled: string[][] = [];
+  let target1 = {
+    foo: function() {
+    },
+    bar: function() {
+      target1barWasCalled.push(slice.call(arguments));
+    }
+  };
+  guidIndexer.push(target1);
+
+  queue.pushUnique(target1, target1.foo);
+  queue.pushUnique(target1, target1.bar, ['a']);
+  queue.pushUnique(target1, target1.bar, ['b']);
+
+  assert.deepEqual(target1barWasCalled, []);
+
+  queue.flush();
+
+  assert.deepEqual(target1barWasCalled.length, 1, 'expected: target 1.bar to be called only once');
+});


### PR DESCRIPTION
In order for Ember to migrate the `Ember.guidFor` API to use WeakMap's we must add configuration in Backburner so that Ember can provide a mechanism to find an object's guid other than indexing into the object itself.

Supporting https://github.com/emberjs/ember.js/pull/15143.