### PR TITLE
check for null only

### DIFF
--- a/lib/backburner/queue.ts
+++ b/lib/backburner/queue.ts
@@ -82,7 +82,7 @@ export default class Queue {
       errorRecordedForStack = queueItems[i + 3]; // Debugging assistance
 
       // method could have been nullified / canceled during flush
-      if (method) {
+      if (method !== null) {
         //
         //    ** Attention intrepid developer **
         //


### PR DESCRIPTION
for other cases I think it is better i throws for debugging reasons