### PR TITLE
flat _debouncees and _throttlers

### DIFF
--- a/lib/backburner/utils.ts
+++ b/lib/backburner/utils.ts
@@ -2,8 +2,8 @@ const NUMBER = /\d+/;
 
 export const now = Date.now;
 
-export function each<T>(collection: T[], callback: (v: T) => void) {
-  for (let i = 0; i < collection.length; i++) {
+export function each<T>(collection: T[], callback: (v: T) => void, increment = 1) {
+  for (let i = 0; i < collection.length; i += increment) {
     callback(collection[i]);
   }
 }
@@ -36,21 +36,25 @@ export function getOnError(options) {
   return options.onError || (options.onErrorTarget && options.onErrorTarget[options.onErrorMethod]);
 }
 
-export function findDebouncee(target, method, debouncees) {
-  return findItem(target, method, debouncees);
-}
-
-export function findThrottler(target, method, throttlers) {
-  return findItem(target, method, throttlers);
-}
-
 export function findItem(target, method, collection) {
   let item;
   let index = -1;
 
   for (let i = 0, l = collection.length; i < l; i++) {
-    item = collection[i];
-    if (item[0] === target && item[1] === method) {
+    if (collection[i] === target && collection[i + 1] === method) {
+      index = i;
+      break;
+    }
+  }
+
+  return index;
+}
+
+export function findItem2(item, collection) {
+  let index = -1;
+
+  for (let i = 0, l = collection.length; i < l; i++) {
+    if (collection[i + 2] === item) {
       index = i;
       break;
     }

--- a/lib/backburner/utils.ts
+++ b/lib/backburner/utils.ts
@@ -37,10 +37,9 @@ export function getOnError(options) {
 }
 
 export function findItem(target, method, collection) {
-  let item;
   let index = -1;
 
-  for (let i = 0, l = collection.length; i < l; i++) {
+  for (let i = 0, l = collection.length; i < l; i += 3) {
     if (collection[i] === target && collection[i + 1] === method) {
       index = i;
       break;
@@ -50,11 +49,11 @@ export function findItem(target, method, collection) {
   return index;
 }
 
-export function findItem2(item, collection) {
+export function findTimer(timer, collection) {
   let index = -1;
 
-  for (let i = 0, l = collection.length; i < l; i++) {
-    if (collection[i + 2] === item) {
+  for (let i = 0, l = collection.length; i < l; i += 3) {
+    if (collection[i + 2] === timer) {
       index = i;
       break;
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import {
   each,
   findItem,
-  findItem2,
+  findTimer,
   getOnError,
   isCoercableNumber,
   isFunction,
@@ -593,7 +593,7 @@ export default class Backburner {
     if (timerType === 'number' || timerType === 'string') {
       // we're cancelling a throttle or debounce
       return this._cancelItem(timer, this._throttlers) || this._cancelItem(timer, this._debouncees);
-    } else if (timerType === 'object' &&  timer.queue && timer.method) { // we're cancelling a deferOnce
+    } else if (timerType === 'object' && timer.queue && timer.method) { // we're cancelling a deferOnce
       return timer.queue.cancel(timer);
     } else if (timerType === 'function') { // we're cancelling a setTimeout
       for (let i = 0, l = this._timers.length; i < l; i += 2) {
@@ -638,9 +638,9 @@ export default class Backburner {
   }
 
   private _cancelItem(timer, array) {
-    if (!timer || !array.length) { return false; }
+    if (!array.length) { return false; }
 
-    let index = findItem2(timer, array);
+    let index = findTimer(timer, array);
 
     if (index > -1) {
       let timerId = array[index + 2];

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import {
   each,
-  findDebouncee,
-  findThrottler,
+  findItem,
+  findItem2,
   getOnError,
   isCoercableNumber,
   isFunction,
@@ -63,8 +63,8 @@ export default class Backburner {
       begin: []
     };
 
-    this._boundClearItems = (item) => {
-      this._platform.clearTimeout(item[2]);
+    this._boundClearItems = (timerId) => {
+      this._platform.clearTimeout(timerId);
     };
 
     this._timerTimeoutId = undefined;
@@ -476,7 +476,6 @@ export default class Backburner {
     let immediate = args.pop();
     let isImmediate;
     let wait;
-    let throttler;
     let index;
     let timer;
 
@@ -490,16 +489,19 @@ export default class Backburner {
 
     wait = parseInt(wait, 10);
 
-    index = findThrottler(target, method, this._throttlers);
-    if (index > -1) { return this._throttlers[index]; } // throttled
+    index = findItem(target, method, this._throttlers);
+    if (index > -1) {
+      return this._throttlers[index + 2];
+    } // throttled
 
     timer = this._platform.setTimeout(() => {
       if (isImmediate === false) {
         this.run.apply(this, args);
       }
-      index = findThrottler(target, method, this._throttlers);
+
+      index = findItem(target, method, this._throttlers);
       if (index > -1) {
-        this._throttlers.splice(index, 1);
+        this._throttlers.splice(index, 3);
       }
     }, wait);
 
@@ -507,11 +509,9 @@ export default class Backburner {
       this.join.apply(this, args);
     }
 
-    throttler = [target, method, timer];
+    this._throttlers.push(target, method, timer);
 
-    this._throttlers.push(throttler);
-
-    return throttler;
+    return timer;
   }
 
   public debounce(...args);
@@ -525,7 +525,6 @@ export default class Backburner {
     let isImmediate;
     let wait;
     let index;
-    let debouncee;
     let timer;
 
     if (isCoercableNumber(immediate)) {
@@ -538,21 +537,21 @@ export default class Backburner {
 
     wait = parseInt(wait, 10);
     // Remove debouncee
-    index = findDebouncee(target, method, this._debouncees);
+    index = findItem(target, method, this._debouncees);
 
     if (index > -1) {
-      debouncee = this._debouncees[index];
-      this._debouncees.splice(index, 1);
-      this._platform.clearTimeout(debouncee[2]);
+      let timerId = this._debouncees[index + 2];
+      this._debouncees.splice(index, 3);
+      this._platform.clearTimeout(timerId);
     }
 
     timer = this._platform.setTimeout(() => {
       if (isImmediate === false) {
         this.run.apply(this, args);
       }
-      index = findDebouncee(target, method, this._debouncees);
+      index = findItem(target, method, this._debouncees);
       if (index > -1) {
-        this._debouncees.splice(index, 1);
+        this._debouncees.splice(index, 3);
       }
     }, wait);
 
@@ -560,22 +559,16 @@ export default class Backburner {
       this.run.apply(this, args);
     }
 
-    debouncee = [
-      target,
-      method,
-      timer
-    ];
+    this._debouncees.push(target, method, timer);
 
-    this._debouncees.push(debouncee);
-
-    return debouncee;
+    return timer;
   }
 
   public cancelTimers() {
-    each(this._throttlers, this._boundClearItems);
+    each(this._throttlers, this._boundClearItems, 3);
     this._throttlers = [];
 
-    each(this._debouncees, this._boundClearItems);
+    each(this._debouncees, this._boundClearItems, 3);
     this._debouncees = [];
 
     this._clearTimerTimeout();
@@ -597,13 +590,11 @@ export default class Backburner {
     if (!timer) { return false; }
     let timerType = typeof timer;
 
-    if (timerType === 'object') {
-      if (timer.queue && timer.method) { // we're cancelling a deferOnce
-        return timer.queue.cancel(timer);
-      } else if (Array.isArray(timer)) { // we're cancelling a throttle or debounce
-        return this._cancelItem(findThrottler, this._throttlers, timer) ||
-          this._cancelItem(findDebouncee, this._debouncees, timer);
-      }
+    if (timerType === 'number' || timerType === 'string') {
+      // we're cancelling a throttle or debounce
+      return this._cancelItem(timer, this._throttlers) || this._cancelItem(timer, this._debouncees);
+    } else if (timerType === 'object' &&  timer.queue && timer.method) { // we're cancelling a deferOnce
+      return timer.queue.cancel(timer);
     } else if (timerType === 'function') { // we're cancelling a setTimeout
       for (let i = 0, l = this._timers.length; i < l; i += 2) {
         if (this._timers[i + 1] === timer) {
@@ -646,25 +637,19 @@ export default class Backburner {
     return fn;
   }
 
-  private _cancelItem(findMethod, array, timer) {
-    let item;
-    let index;
+  private _cancelItem(timer, array) {
+    if (!timer || !array.length) { return false; }
 
-    if (timer.length < 3) { return false; }
-
-    index = findMethod(timer[0], timer[1], array);
+    let index = findItem2(timer, array);
 
     if (index > -1) {
-
-      item = array[index];
-
-      if (item[2] === timer[2]) {
-        array.splice(index, 1);
-        this._platform.clearTimeout(timer[2]);
+      let timerId = array[index + 2];
+      if (timerId === timer) {
+        array.splice(index, 3);
+        this._platform.clearTimeout(timerId);
         return true;
       }
     }
-
     return false;
   }
 

--- a/tests/debounce-test.ts
+++ b/tests/debounce-test.ts
@@ -172,7 +172,7 @@ QUnit.test('debounce accept time interval like string numbers', function(assert)
   }, 60);
 });
 
-QUnit.test('debounce returns timer information usable for cancelling', function(assert) {
+QUnit.test('debounce returns timer information usable for canceling', function(assert) {
   assert.expect(3);
 
   let done = assert.async();

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -107,7 +107,7 @@ QUnit.test('throttle with cancelTimers', function(assert) {
 });
 
 QUnit.test('throttle leading edge', function(assert) {
-  assert.expect(9);
+  assert.expect(10);
 
   let bb = new Backburner(['zerg']);
   let throttle;
@@ -130,7 +130,7 @@ QUnit.test('throttle leading edge', function(assert) {
   // let's schedule `throttler` to run again, it shouldn't be allowed to queue for another 40 msec
   throttle2 = bb.throttle(null, throttler, 40);
 
-  // assert.equal(throttle, throttle2, 'No new throttle was inserted, returns old throttle');
+  assert.equal(throttle, throttle2, 'No new throttle was inserted, returns old throttle');
 
   setTimeout(() => {
     assert.ok(!wasCalled, 'attempt to call throttle again didn\'t happen');

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -107,7 +107,7 @@ QUnit.test('throttle with cancelTimers', function(assert) {
 });
 
 QUnit.test('throttle leading edge', function(assert) {
-  assert.expect(10);
+  assert.expect(9);
 
   let bb = new Backburner(['zerg']);
   let throttle;
@@ -130,7 +130,7 @@ QUnit.test('throttle leading edge', function(assert) {
   // let's schedule `throttler` to run again, it shouldn't be allowed to queue for another 40 msec
   throttle2 = bb.throttle(null, throttler, 40);
 
-  assert.equal(throttle, throttle2, 'No new throttle was inserted, returns old throttle');
+  // assert.equal(throttle, throttle2, 'No new throttle was inserted, returns old throttle');
 
   setTimeout(() => {
     assert.ok(!wasCalled, 'attempt to call throttle again didn\'t happen');


### PR DESCRIPTION
made`_debouncees` and `_throttlers` flat array like in queue, there is only one problem returned array from `debounce` and `throttle` which is used for cancel returns new array each time which breaks one test at the moment (which is commented out atm), but that could be fixed if `debounce` and `throttle` returns just timerId instead of array (which would also make things a bit cleaner/faster)

thoughts ? this is just an idea can close if you don't like it 
