### PR TITLE
remove redundant check

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -643,12 +643,9 @@ export default class Backburner {
     let index = findTimer(timer, array);
 
     if (index > -1) {
-      let timerId = array[index + 2];
-      if (timerId === timer) {
-        array.splice(index, 3);
-        this._platform.clearTimeout(timerId);
-        return true;
-      }
+      array.splice(index, 3);
+      this._platform.clearTimeout(timer);
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
`findTimer` already compares timerId there is no need to check it again