### PR TITLE
catch error in join

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -276,10 +276,14 @@ export default class Backburner {
       }
     }
 
-    if (length === 1) {
-      return method();
-    } else if (length === 2) {
-      return method.call(target);
+    let onError = getOnError(this.options);
+
+    if (onError) {
+      try {
+        return method.apply(target, args);
+      } catch (error) {
+        onError(error);
+      }
     } else {
       return method.apply(target, args);
     }

--- a/tests/join-test.ts
+++ b/tests/join-test.ts
@@ -95,3 +95,19 @@ QUnit.test('queue execution order', function(assert) {
   });
   assert.deepEqual(items, [0, 1, 2, 3, 4, 5, 6]);
 });
+
+QUnit.test('onError', function(assert) {
+  assert.expect(1);
+
+  function onError(error) {
+    assert.equal('test error', error.message);
+  }
+
+  let bb = new Backburner(['errors'], {
+    onError: onError
+  });
+
+  bb.join(() => {
+    throw new Error('test error');
+  });
+});

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -241,7 +241,7 @@ QUnit.test('throttle + immediate joins existing run loop instances', function(as
   assert.expect(1);
 
   function onError(error) {
-    assert.equal('test error', error.message);
+    throw error;
   }
 
   let bb = new Backburner(['errors'], {
@@ -251,7 +251,7 @@ QUnit.test('throttle + immediate joins existing run loop instances', function(as
   bb.run(() => {
     let parentInstance = bb.currentInstance;
     bb.throttle(null, () => {
-     assert.equal(bb.currentInstance, parentInstance);
+      assert.equal(bb.currentInstance, parentInstance);
     }, 20, true);
   });
 });


### PR DESCRIPTION
to be consistent with `run`