### PR TITLE
debounce immediately run in current run loop

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -535,9 +535,9 @@ export default class Backburner {
     }
 
     wait = parseInt(wait, 10);
+
     // Remove debouncee
     index = findItem(target, method, this._debouncees);
-
     if (index > -1) {
       let timerId = this._debouncees[index + 2];
       this._debouncees.splice(index, 3);
@@ -555,7 +555,7 @@ export default class Backburner {
     }, wait);
 
     if (isImmediate && index === -1) {
-      this.run.apply(this, args);
+      this.join.apply(this, args);
     }
 
     this._debouncees.push(target, method, timer);

--- a/tests/debounce-test.ts
+++ b/tests/debounce-test.ts
@@ -145,6 +145,25 @@ QUnit.test('debounce - immediate', function(assert) {
   }, 120);
 });
 
+QUnit.test('debounce + immediate joins existing run loop instances', function(assert) {
+  assert.expect(1);
+
+  function onError(error) {
+    throw error;
+  }
+
+  let bb = new Backburner(['errors'], {
+    onError: onError
+  });
+
+  bb.run(() => {
+    let parentInstance = bb.currentInstance;
+    bb.debounce(null, () => {
+      assert.equal(bb.currentInstance, parentInstance);
+    }, 20, true);
+  });
+});
+
 QUnit.test('debounce accept time interval like string numbers', function(assert) {
   let done = assert.async();
   let bb = new Backburner(['zomg']);


### PR DESCRIPTION
throttles immediate flag call throttled method with `join` (https://github.com/BackburnerJS/backburner.js/blob/master/lib/index.ts#L508) while debounce is with run, this fixes it 