### PR TITLE
add error stack to `.later`

### DIFF
--- a/lib/backburner/binary-search.ts
+++ b/lib/backburner/binary-search.ts
@@ -1,24 +1,24 @@
 export default function binarySearch(time, timers) {
   let start = 0;
-  let end = timers.length - 2;
+  let end = timers.length - 5;
   let middle;
   let l;
 
   while (start < end) {
     // since timers is an array of pairs 'l' will always
     // be an integer
-    l = (end - start) / 2;
+    l = (end - start) / 5;
 
     // compensate for the index in case even number
     // of pairs inside timers
-    middle = start + l - (l % 2);
+    middle = start + l - (l % 5);
 
     if (time >= timers[middle]) {
-      start = middle + 2;
+      start = middle + 5;
     } else {
       end = middle;
     }
   }
 
-  return (time >= timers[start]) ? start + 2 : start;
+  return (time >= timers[start]) ? start + 5 : start;
 }

--- a/lib/backburner/binary-search.ts
+++ b/lib/backburner/binary-search.ts
@@ -1,24 +1,24 @@
 export default function binarySearch(time, timers) {
   let start = 0;
-  let end = timers.length - 5;
+  let end = timers.length - 6;
   let middle;
   let l;
 
   while (start < end) {
     // since timers is an array of pairs 'l' will always
     // be an integer
-    l = (end - start) / 5;
+    l = (end - start) / 6;
 
     // compensate for the index in case even number
     // of pairs inside timers
-    middle = start + l - (l % 5);
+    middle = start + l - (l % 6);
 
     if (time >= timers[middle]) {
-      start = middle + 5;
+      start = middle + 6;
     } else {
       end = middle;
     }
   }
 
-  return (time >= timers[start]) ? start + 5 : start;
+  return (time >= timers[start]) ? start + 6 : start;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -660,7 +660,7 @@ export default class Backburner {
         let method = timers[i + 3];
         let args = timers[i + 4];
         let stack = this.DEBUG ? new Error() : undefined;
-        this.currentInstance.schedule(defaultQueue, target, method, args, false, stack);
+        this.currentInstance!.schedule(defaultQueue, target, method, args, false, stack);
       } else {
         break;
       }


### PR DESCRIPTION
* adds error stack recording to `.later` as in `.schedule` `.scheduleOnce`...
* avoids creating extra closure that wraps `.later` callback
* from benchmarks this does not bring any performance improvements ~~(there is 5% drop in `Later &  Cancel - function, target` case benchmark)~~

any thoughts ? if you like the idea will squash and cleanup 