### PR TITLE
remove `now` from util

### DIFF
--- a/lib/backburner/utils.ts
+++ b/lib/backburner/utils.ts
@@ -1,7 +1,5 @@
 const NUMBER = /\d+/;
 
-export const now = Date.now;
-
 export function each<T>(collection: T[], callback: (v: T) => void, increment = 1) {
   for (let i = 0; i < collection.length; i += increment) {
     callback(collection[i]);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,8 +5,7 @@ import {
   getOnError,
   isCoercableNumber,
   isFunction,
-  isString,
-  now
+  isString
 } from './backburner/utils';
 
 import searchTimer from './backburner/binary-search';
@@ -15,6 +14,7 @@ import iteratorDrain from './backburner/iterator-drain';
 
 import Queue, { QUEUE_STATE } from './backburner/queue';
 
+const now = Date.now;
 const noop = function() {};
 
 export default class Backburner {


### PR DESCRIPTION
since there is no fallback on `now` I think there is no need it for keeping `now` inside util