### PR TITLE
fixed bug when `cancelTimers` would not clear debounce/throttle timers

### DIFF
--- a/lib/backburner/deferred-action-queues.ts
+++ b/lib/backburner/deferred-action-queues.ts
@@ -1,6 +1,5 @@
 import Queue, { QUEUE_STATE } from './queue';
 import {
-  each,
   noSuchMethod,
   noSuchQueue
 } from './utils';
@@ -16,10 +15,10 @@ export default class DeferredActionQueues {
     this.options = options;
     this.queueNames = queueNames;
 
-    let queues = this.queues;
-    each(queueNames, function(queueName) {
+    queueNames.reduce(function(queues, queueName) {
       queues[queueName] = new Queue(queueName, options[queueName], options);
-    });
+      return queues;
+    }, this.queues);
   }
 
   /*

--- a/lib/backburner/utils.ts
+++ b/lib/backburner/utils.ts
@@ -1,11 +1,5 @@
 const NUMBER = /\d+/;
 
-export function each<T>(collection: T[], callback: (v: T) => void, increment = 1, start = 0) {
-  for (let i = start; i < collection.length; i += increment) {
-    callback(collection[i]);
-  }
-}
-
 export function isString(suspect: any): suspect is string {
   return typeof suspect === 'string';
 }

--- a/lib/backburner/utils.ts
+++ b/lib/backburner/utils.ts
@@ -1,7 +1,7 @@
 const NUMBER = /\d+/;
 
-export function each<T>(collection: T[], callback: (v: T) => void, increment = 1) {
-  for (let i = 0; i < collection.length; i += increment) {
+export function each<T>(collection: T[], callback: (v: T) => void, increment = 1, start = 0) {
+  for (let i = start; i < collection.length; i += increment) {
     callback(collection[i]);
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
 import {
-  each,
   findItem,
   findTimer,
   getOnError,
@@ -37,7 +36,6 @@ export default class Backburner {
     begin: Function[];
   };
 
-  private _boundClearItems: (item) => void;
   private _timerTimeoutId: number | null = null;
   private _timers: any[];
   private _platform: {
@@ -70,10 +68,6 @@ export default class Backburner {
 
     this._onBegin = this.options.onBegin || noop;
     this._onEnd = this.options.onEnd || noop;
-
-    this._boundClearItems = (timerId) => {
-      this._platform.clearTimeout(timerId);
-    };
 
     let _platform = this.options._platform || {};
     let platform = Object.create(null);
@@ -556,10 +550,14 @@ export default class Backburner {
   }
 
   public cancelTimers() {
-    each(this._throttlers, this._boundClearItems, 3, 2);
+    for (let i = 2; i < this._throttlers.length; i += 3) {
+      this._platform.clearTimeout(this._throttlers[i]);
+    }
     this._throttlers = [];
 
-    each(this._debouncees, this._boundClearItems, 3, 2);
+    for (let t = 2; t < this._debouncees.length; t += 3) {
+      this._platform.clearTimeout(this._debouncees[t]);
+    }
     this._debouncees = [];
 
     this._clearTimerTimeout();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -556,10 +556,10 @@ export default class Backburner {
   }
 
   public cancelTimers() {
-    each(this._throttlers, this._boundClearItems, 3);
+    each(this._throttlers, this._boundClearItems, 3, 2);
     this._throttlers = [];
 
-    each(this._debouncees, this._boundClearItems, 3);
+    each(this._debouncees, this._boundClearItems, 3, 2);
     this._debouncees = [];
 
     this._clearTimerTimeout();

--- a/tests/cancel-test.ts
+++ b/tests/cancel-test.ts
@@ -107,11 +107,13 @@ QUnit.test('cancelTimers', function(assert) {
   let done = assert.async();
 
   let bb = new Backburner(['one']);
-  let functionWasCalled = false;
+  let laterWasCalled = false;
+  let debounceWasCalled = false;
+  let throttleWasCalled = false;
 
-  let timer1 = bb.later(() => functionWasCalled = true, 0);
-  let timer2 = bb.debounce(() => functionWasCalled = true, 0);
-  let timer3 = bb.throttle(() => functionWasCalled = true, 0, false);
+  let timer1 = bb.later(() => laterWasCalled = true, 0);
+  let timer2 = bb.debounce(() => debounceWasCalled = true, 0);
+  let timer3 = bb.throttle(() => throttleWasCalled = true, 0, false);
 
   assert.ok(timer1, 'Timer object was returned');
   assert.ok(timer2, 'Timer object was returned');
@@ -122,7 +124,9 @@ QUnit.test('cancelTimers', function(assert) {
 
   setTimeout(function() {
     assert.ok(!bb.hasTimers(), 'bb has no scheduled timer');
-    assert.ok(!functionWasCalled, 'function was not called');
+    assert.ok(!laterWasCalled, 'later function was not called');
+    assert.ok(!debounceWasCalled, 'debounce function was not called');
+    assert.ok(!throttleWasCalled, 'throttle function was not called');
     done();
   }, 100);
 });

--- a/tests/cancel-test.ts
+++ b/tests/cancel-test.ts
@@ -104,18 +104,27 @@ QUnit.test('setTimeout and creating a new later', function(assert) {
 });
 
 QUnit.test('cancelTimers', function(assert) {
+  let done = assert.async();
+
   let bb = new Backburner(['one']);
   let functionWasCalled = false;
 
-  let timer = bb.later(() => functionWasCalled = true);
+  let timer1 = bb.later(() => functionWasCalled = true, 0);
+  let timer2 = bb.debounce(() => functionWasCalled = true, 0);
+  let timer3 = bb.throttle(() => functionWasCalled = true, 0, false);
 
-  assert.ok(timer, 'Timer object was returned');
+  assert.ok(timer1, 'Timer object was returned');
+  assert.ok(timer2, 'Timer object was returned');
+  assert.ok(timer3, 'Timer object was returned');
   assert.ok(bb.hasTimers(), 'bb has scheduled timer');
 
   bb.cancelTimers();
 
-  assert.ok(!bb.hasTimers(), 'bb has no scheduled timer');
-  assert.ok(!functionWasCalled, 'function was not called');
+  setTimeout(function() {
+    assert.ok(!bb.hasTimers(), 'bb has no scheduled timer');
+    assert.ok(!functionWasCalled, 'function was not called');
+    done();
+  }, 100);
 });
 
 QUnit.test('cancel during flush', function(assert) {

--- a/tests/cancel-test.ts
+++ b/tests/cancel-test.ts
@@ -104,6 +104,7 @@ QUnit.test('setTimeout and creating a new later', function(assert) {
 });
 
 QUnit.test('cancelTimers', function(assert) {
+  assert.expect(8);
   let done = assert.async();
 
   let bb = new Backburner(['one']);


### PR DESCRIPTION
because `each` iterated on wrong items, timers where not cleared, also added test to avoid that in the future