### PR TITLE
[BUGFIX] fix throttle final argument usage

### DIFF
--- a/lib/backburner/utils.ts
+++ b/lib/backburner/utils.ts
@@ -44,9 +44,9 @@ export function findItem(target, method, collection) {
 export function findTimer(timer, collection) {
   let index = -1;
 
-  for (let i = 2; i < collection.length; i += 3) {
+  for (let i = 3; i < collection.length; i += 4) {
     if (collection[i] === timer) {
-      index = i - 2;
+      index = i - 3;
       break;
     }
   }

--- a/tests/debounce-test.ts
+++ b/tests/debounce-test.ts
@@ -238,6 +238,22 @@ QUnit.test('debounce cancelled after it\'s executed returns false', function(ass
 
 });
 
+QUnit.test('debounced function is called with final argument', function(assert) {
+  assert.expect(1);
+
+  let done = assert.async();
+  let bb = new Backburner(['joker']);
+
+  function debouncee(arg) {
+    assert.equal('bus', arg, 'the debounced is called with right argument');
+    done();
+  }
+
+  bb.debounce(null, debouncee, 'car', 10);
+  bb.debounce(null, debouncee, 'bicycle', 10);
+  bb.debounce(null, debouncee, 'bus', 10);
+});
+
 QUnit.test('debounce cancelled doesn\'t cancel older items', function(assert) {
   assert.expect(4);
 

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -106,6 +106,23 @@ QUnit.test('throttle with cancelTimers', function(assert) {
   assert.equal(count, 0, 'calling cancelTimers while something is being throttled does not throw an error');
 });
 
+QUnit.test('throttled function is called with final argument', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  let count = 0;
+  let bb = new Backburner(['zomg']);
+
+  function throttled(arg) {
+    assert.equal(arg, 'bus');
+    done();
+  }
+
+  bb.throttle(null, throttled, 'car' , 10, false);
+  bb.throttle(null, throttled, 'bicycle' , 10, false);
+  bb.throttle(null, throttled, 'bus' , 10, false);
+});
+
 QUnit.test('throttle leading edge', function(assert) {
   assert.expect(10);
 


### PR DESCRIPTION
`bb.debounce` uses final/last argument passed to it while `bb.throttle` does not, this PR fixes it 

```
  bb.debounce(null, debouncee, 'car', 10);
  bb.debounce(null, debouncee, 'bus', 10);
// would call debouncee with `bus`

  bb.throttle(null, throttled, 'car' , 10, false);
  bb.throttle(null, throttled, 'bus' , 10, false);
// before: would call throttled with `car`
// now: calls throttled with `bus`
```
