### PR TITLE
[BUGFIX] fix regression when `findItem` iterated incorrectly

### DIFF
--- a/lib/backburner/utils.ts
+++ b/lib/backburner/utils.ts
@@ -31,7 +31,7 @@ export function getOnError(options) {
 export function findItem(target, method, collection) {
   let index = -1;
 
-  for (let i = 0, l = collection.length; i < l; i += 3) {
+  for (let i = 0, l = collection.length; i < l; i += 4) {
     if (collection[i] === target && collection[i + 1] === method) {
       index = i;
       break;

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -123,6 +123,23 @@ QUnit.test('throttled function is called with final argument', function(assert) 
   bb.throttle(null, throttled, 'bus' , 10, false);
 });
 
+QUnit.test('throttle returns same timer', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['joker']);
+
+  function throttled1() {}
+  function throttled2() {}
+
+  let timer1 = bb.throttle(null, throttled1, 10);
+  let timer2 = bb.throttle(null, throttled2, 10);
+  let timer3 = bb.throttle(null, throttled1, 10);
+  let timer4 = bb.throttle(null, throttled2, 10);
+
+  assert.equal(timer1, timer3);
+  assert.equal(timer2, timer4);
+});
+
 QUnit.test('throttle leading edge', function(assert) {
   assert.expect(10);
 


### PR DESCRIPTION
with #273 it regressed, forgot to modify `findItem` to iterate with 4 steps since collection contains 4 element chains, added test avoid it in the future