### PR TITLE
Rethrow error in join

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -272,7 +272,7 @@ export default class Backburner {
         return method.apply(target, args);
       } catch (error) {
         onError(error);
-	throw error;
+        throw error;
       }
     } else {
       return method.apply(target, args);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -272,6 +272,7 @@ export default class Backburner {
         return method.apply(target, args);
       } catch (error) {
         onError(error);
+	throw error;
       }
     } else {
       return method.apply(target, args);


### PR DESCRIPTION
Fixes #274. It seems undesirable to swallow an error merely as a result of registering an error handler as this changes the logic of promise chains that involve the runloop in a way that is contingent on an error handler, which generally seem used for passing logging.