### PR TITLE
Revert extra try/catch wrapping of `run.join`.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -265,14 +265,10 @@ export default class Backburner {
       }
     }
 
-    let onError = getOnError(this.options);
-
-    if (onError) {
-      try {
-        return method.apply(target, args);
-      } catch (error) {
-        onError(error);
-      }
+    if (length === 1) {
+      return method();
+    } else if (length === 2) {
+      return method.call(target);
     } else {
       return method.apply(target, args);
     }

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -258,7 +258,7 @@ QUnit.test('throttle + immediate joins existing run loop instances', function(as
   assert.expect(1);
 
   function onError(error) {
-    throw error;
+    assert.equal('test error', error.message);
   }
 
   let bb = new Backburner(['errors'], {
@@ -268,7 +268,7 @@ QUnit.test('throttle + immediate joins existing run loop instances', function(as
   bb.run(() => {
     let parentInstance = bb.currentInstance;
     bb.throttle(null, () => {
-      assert.equal(bb.currentInstance, parentInstance);
+     assert.equal(bb.currentInstance, parentInstance);
     }, 20, true);
   });
 });


### PR DESCRIPTION
4c26eedcb added `try`/`catch` wrapping to `Backburner.prototype.join` in the scenario where it is actually joining an existing instance. This seemed completely valid on the surface (who would want to introduce error swallowing?!?!?!), but unfortunately it actually introduced a regression.

In the case where `run.join` is called without already being within an existing instance, it was already properly handling `try`/`catch` wrapping and calling the provided `onError`. In fact, the test added in ed3dd0a demonstrates exactly that! The test was intending to cover the new logic, but it actually only covers the error handling behaviors of `Backburner.prototype.run` itself.

In the case where `run.join` is called from within an existing instance, the new logic _introduced_ error swallowing behaviors when the `onError` callback itself did not rethrow the error. This is because `run.join` from within an existing instance is _already_ invoked from within `Queue.prototype.invokeWithOnError`.

The added `try`/`catch` wrapping that was added in 4c26eedcb caused the regression reported in https://github.com/BackburnerJS/backburner.js/issues/274 (and https://github.com/emberjs/ember.js/issues/15864), due to the usage of `run.bind` to wrap the rejection handler combined with the fact that Ember configures RSVP to handle all promise resolution within a Backburner queue which essentially created this situation:

```js
let bb = new Backburner(['errors'], {
  onError(error) { console.log(error.message) }
});

bb.run(() => {
  try {
    // RSVP runs the then callbacks here
    // in the example case, the callbacks were also
    // wrapped in `run.bind` (which uses run.join internally)

    // this simulates the run.bind callback from the example
    bb.join(() => {
      throw new Error('foo');
    });

    // after 4c26eedcb the bb.join above no longer bubbles errors
    // because the registered onError does not rethrow
  } catch(e) {
    // RSVP relies on this error catching to know that a promise
    // should be properly rejected
  }
});
```

This PR adds a number of additional tests for various combinations of `Backburner.prototype.join`, having an `onError` setup, joining an existing instance, creating a new instance.

Fixes #274
Closes #276
Addresses emberjs/ember.js#15864