### PR TITLE
get `onError` only when necessary for `.run`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -513,24 +513,19 @@ export default class Backburner {
   }
 
   private _run(target, method, args) {
-    let onError = getOnError(this.options);
-
     this.begin();
 
-    if (onError) {
-      try {
-        return method.apply(target, args);
-      } catch (error) {
+    try {
+      return method.apply(target, args);
+    } catch (error) {
+      let onError = getOnError(this.options);
+      if (onError) {
         onError(error);
-      } finally {
-        this.end();
+      } else {
+        throw error;
       }
-    } else {
-      try {
-        return method.apply(target, args);
-      } finally {
-        this.end();
-      }
+    } finally {
+      this.end();
     }
   }
 


### PR DESCRIPTION
`try {} catch() finally {}` and `try {} catch()` should probably perform equally (will try to add benchmarks for it) therefore it is better just use `try {} catch() finally {}`