### PR TITLE
avoid boolean coercion in `invoke` and  `invokeWithOnError`

### DIFF
--- a/lib/backburner/queue.ts
+++ b/lib/backburner/queue.ts
@@ -215,7 +215,7 @@ export default class Queue {
   }
 
   private invoke(target, method, args /*, onError, errorRecordedForStack */) {
-    if (args && args.length > 0) {
+    if (args !== undefined) {
       method.apply(target, args);
     } else {
       method.call(target);
@@ -224,7 +224,7 @@ export default class Queue {
 
   private invokeWithOnError(target, method, args, onError, errorRecordedForStack) {
     try {
-      if (args && args.length > 0) {
+      if (args !== undefined) {
         method.apply(target, args);
       } else {
         method.call(target);


### PR DESCRIPTION
since using `parseArgs` args are either passed or not passed, so just checking for `undefined` is enough