### PR TITLE
[BUGFIX] properly cancel unique target tasks

### DIFF
--- a/lib/backburner/queue.ts
+++ b/lib/backburner/queue.ts
@@ -126,17 +126,21 @@ export default class Queue {
     let guid = this.guidForTarget(target);
     let targetQueue = guid ? this.targetQueues[guid] : undefined;
 
+    let index;
     if (targetQueue !== undefined) {
       let t;
       for (let i = 0, l = targetQueue.length; i < l; i += 2) {
         t = targetQueue[i];
         if (t === method) {
-          targetQueue.splice(i, 1);
+          index = targetQueue.splice(i, 2)[1];
         }
       }
     }
 
-    let index = findItem(target, method, queue);
+    if (index === undefined) {
+      index = findItem(target, method, queue);
+    }
+
     if (index > -1) {
       queue.splice(index, 4);
       return true;


### PR DESCRIPTION
because of incorrectly canceling unique target tasks, later added tasks could be added without uniqueness 