### PR TITLE
[BUGFIX master] properly cancel items which are added during flush

### DIFF
--- a/lib/backburner/queue.ts
+++ b/lib/backburner/queue.ts
@@ -109,17 +109,11 @@ export default class Queue {
     let queue = this._queue;
     let targetQueueMap = this.targetQueues.get(target);
 
-    let index;
     if (targetQueueMap !== undefined) {
-      index = targetQueueMap.get(method);
-      if (index !== undefined) {
-        targetQueueMap.delete(method);
-      }
+      targetQueueMap.delete(method);
     }
 
-    if (index === undefined) {
-      index = findItem(target, method, queue);
-    }
+    let index = findItem(target, method, queue);
 
     if (index > -1) {
       queue.splice(index, 4);

--- a/tests/multi-turn-test.ts
+++ b/tests/multi-turn-test.ts
@@ -79,3 +79,50 @@ QUnit.test('basic', function(assert) {
     three: { count: 1, order:  2 }
   }, 'TaskOne, TaskTwo and TaskThree has been run before the platform flushes');
 });
+
+QUnit.test('properly cancel items which are added during flush', function(assert) {
+  let bb = new Backburner(['zomg'], {
+    // This is just a place holder for now, but somehow the system needs to
+    // know to when to stop
+    mustYield() {
+      return true; // yield after each step, for now.
+    },
+
+    _platform: platform
+  });
+
+  let fooCalled = 0;
+  let barCalled = 0;
+
+  let obj1 = {
+    foo() {
+      fooCalled++;
+    }
+  };
+
+  let obj2 = {
+    bar() {
+      barCalled++;
+    }
+  };
+
+  bb.scheduleOnce('zomg', obj1, 'foo');
+  bb.scheduleOnce('zomg', obj1, 'foo');
+  bb.scheduleOnce('zomg', obj2, 'bar');
+  bb.scheduleOnce('zomg', obj2, 'bar');
+
+  platform.flushSync();
+
+  let timer1 = bb.scheduleOnce('zomg', obj1, 'foo');
+  let timer2 = bb.scheduleOnce('zomg', obj2, 'bar');
+  bb.cancel(timer1);
+  bb.cancel(timer2);
+
+  platform.flushSync();
+  platform.flushSync();
+  platform.flushSync();
+
+  assert.equal(fooCalled, 1, 'fooCalled');
+  assert.equal(barCalled, 1, 'barCalled');
+
+});


### PR DESCRIPTION
~possible bugfix, `targetQueues` should be cleared only when `_queue ` moved to `_queueBeingFlushed`   else `queueIndex`es could be messed up https://github.com/BackburnerJS/backburner.js/blob/master/lib/backburner/queue.ts#L152~