### PR TITLE
Use microtask queue to flush autoruns...

### DIFF
--- a/lib/backburner/deferred-action-queues.ts
+++ b/lib/backburner/deferred-action-queues.ts
@@ -48,7 +48,7 @@ export default class DeferredActionQueues {
     @method flush
     DeferredActionQueues.flush() calls Queue.flush()
   */
-  public flush() {
+  public flush(fromAutorun = false) {
     let queue;
     let queueName;
     let numberOfQueues = this.queueNames.length;
@@ -59,6 +59,9 @@ export default class DeferredActionQueues {
 
       if (queue.hasWork() === false) {
         this.queueNameIndex++;
+        if (fromAutorun) {
+          return QUEUE_STATE.Pause;
+        }
       } else {
         if (queue.flush(false /* async */) === QUEUE_STATE.Pause) {
           return QUEUE_STATE.Pause;

--- a/lib/backburner/platform.ts
+++ b/lib/backburner/platform.ts
@@ -1,0 +1,52 @@
+export interface IPlatform {
+  setTimeout(fn: Function, ms: number): any;
+  clearTimeout(id: any): void;
+  next(): any;
+  clearNext(timerId: any): void;
+  now(): number;
+}
+
+const SET_TIMEOUT = setTimeout;
+const NOOP = () => {};
+
+export function buildPlatform(flush: () => void): IPlatform {
+  let next;
+  let clearNext = NOOP;
+
+  if (typeof MutationObserver === 'function') {
+    let iterations = 0;
+    let observer = new MutationObserver(flush);
+    let node = document.createTextNode('');
+    observer.observe(node, { characterData: true });
+
+    next = () => {
+      iterations = ++iterations % 2;
+      node.data = '' + iterations;
+      return iterations;
+    };
+
+  } else if (typeof Promise === 'function') {
+    const autorunPromise = Promise.resolve();
+    next = () => autorunPromise.then(flush);
+
+  } else {
+    next = () => SET_TIMEOUT(flush, 0);
+  }
+
+  return {
+    setTimeout(fn, ms) {
+      return SET_TIMEOUT(fn, ms);
+    },
+
+    clearTimeout(timerId: number) {
+      return clearTimeout(timerId);
+    },
+
+    now() {
+      return Date.now();
+    },
+
+    next,
+    clearNext,
+  };
+}

--- a/lib/backburner/queue.ts
+++ b/lib/backburner/queue.ts
@@ -33,7 +33,7 @@ export default class Queue {
     }
   }
 
-  public flush(sync?) {
+  public flush(sync?: Boolean) {
     let { before, after } = this.options;
     let target;
     let method;

--- a/tests/autorun-test.ts
+++ b/tests/autorun-test.ts
@@ -11,7 +11,7 @@ QUnit.test('autorun', function(assert) {
   assert.equal(step++, 0);
 
   bb.schedule('zomg', null, () => {
-    assert.equal(step, 2);
+    assert.equal(step++, 2);
     setTimeout(() => {
       assert.ok(!bb.hasTimers(), 'The all timers are cleared');
       done();
@@ -57,4 +57,42 @@ QUnit.test('autorun (joins next run if not yet flushed)', function(assert) {
     one: { count: 1, order: 0 },
     two: { count: 1, order: 1 }
   });
+});
+
+QUnit.test('autorun completes before items scheduled by later (via microtasks)', function(assert) {
+  let done = assert.async();
+  let bb = new Backburner(['first', 'second']);
+  let order = new Array();
+
+  // this later will be scheduled into the `first` queue when
+  // its timer is up
+  bb.later(() => {
+    order.push('second - later');
+  }, 0);
+
+  // scheduling this into the second queue so that we can confirm this _still_
+  // runs first (due to autorun resolving before scheduled timer)
+  bb.schedule('second', null, () => {
+    order.push('first - scheduled');
+  });
+
+  setTimeout(() => {
+    assert.deepEqual(order, ['first - scheduled', 'second - later']);
+    done();
+  }, 20);
+});
+
+QUnit.test('can be canceled (private API)', function(assert) {
+  assert.expect(0);
+
+  let done = assert.async();
+  let bb = new Backburner(['zomg']);
+
+  bb.schedule('zomg', null, () => {
+    assert.notOk(true, 'should not flush');
+  });
+
+  bb['_cancelAutorun']();
+
+  setTimeout(done, 10);
 });

--- a/tests/configurable-timeout-test.ts
+++ b/tests/configurable-timeout-test.ts
@@ -1,75 +1,81 @@
-import Backburner from 'backburner';
+import Backburner, { buildPlatform } from 'backburner';
 
 QUnit.module('tests/configurable-timeout');
 
 QUnit.test('We can configure a custom platform', function(assert) {
   assert.expect(1);
 
-  let fakePlatform = {
-    setTimeout() {},
-    clearTimeout() {},
-    isFakePlatform: true
-  };
-
   let bb = new Backburner(['one'], {
-    _platform: fakePlatform
+    _buildPlatform(flush) {
+      let platform = buildPlatform(flush);
+      platform['isFakePlatform'] = true;
+      return platform;
+    }
   });
 
-  assert.ok(bb.options._platform.isFakePlatform, 'We can pass in a custom platform');
+  assert.ok(bb['_platform']!['isFakePlatform'], 'We can pass in a custom platform');
 });
 
 QUnit.test('We can use a custom setTimeout', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
   let done = assert.async();
 
   let customNextWasUsed = false;
   let bb = new Backburner(['one'], {
-    _platform: {
-      next() {
-        throw new TypeError('NOT IMPLEMENTED');
-      },
-      setTimeout(cb) {
-        customNextWasUsed = true;
-        return setTimeout(cb);
-      },
-      clearTimeout(timer) {
-        return clearTimeout(timer);
-      },
-      isFakePlatform: true
+    _buildPlatform(flush) {
+      return {
+        next() {
+          throw new TypeError('NOT IMPLEMENTED');
+        },
+        clearNext() { },
+        setTimeout(cb) {
+          customNextWasUsed = true;
+          return setTimeout(cb);
+        },
+        clearTimeout(timer) {
+          return clearTimeout(timer);
+        },
+        now() {
+          return Date.now();
+        },
+        isFakePlatform: true
+      };
     }
   });
 
   bb.setTimeout(() => {
-    assert.ok(bb.options._platform.isFakePlatform, 'we are using the fake platform');
     assert.ok(customNextWasUsed , 'custom later was used');
     done();
   });
 });
 
 QUnit.test('We can use a custom next', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
   let done = assert.async();
 
   let customNextWasUsed = false;
   let bb = new Backburner(['one'], {
-    _platform: {
-      setTimeout() {
-        throw new TypeError('NOT IMPLEMENTED');
-      },
-      next(cb) {
-        // next is used for the autorun
-        customNextWasUsed = true;
-        return setTimeout(cb);
-      },
-      clearTimeout(timer) {
-        return clearTimeout(timer);
-      },
-      isFakePlatform: true
+    _buildPlatform(flush) {
+      return {
+        setTimeout() {
+          throw new TypeError('NOT IMPLEMENTED');
+        },
+        clearTimeout(timer) {
+          return clearTimeout(timer);
+        },
+        next() {
+          // next is used for the autorun
+          customNextWasUsed = true;
+          return setTimeout(flush);
+        },
+        clearNext() { },
+        now() { return Date.now(); },
+        isFakePlatform: true
+      };
     }
   });
 
   bb.scheduleOnce('one', () => {
-    assert.ok(bb.options._platform.isFakePlatform, 'we are using the fake platform');
     assert.ok(customNextWasUsed , 'custom later was used');
     done();
   });
@@ -81,21 +87,26 @@ QUnit.test('We can use a custom clearTimeout', function(assert) {
   let functionWasCalled = false;
   let customClearTimeoutWasUsed = false;
   let bb = new Backburner(['one'], {
-    _platform: {
-      setTimeout(method, wait) {
-        return setTimeout(method, wait);
-      },
-      clearTimeout(timer) {
-        customClearTimeoutWasUsed = true;
-        return clearTimeout(timer);
-      },
-      next(method) {
-        return setTimeout(method, 0);
-      },
-      clearNext(timer) {
-        customClearTimeoutWasUsed = true;
-        return clearTimeout(timer);
-      }
+    _buildPlatform(flush) {
+      return {
+        setTimeout(method, wait) {
+          return setTimeout(method, wait);
+        },
+        clearTimeout(timer) {
+          customClearTimeoutWasUsed = true;
+          return clearTimeout(timer);
+        },
+        next() {
+          return setTimeout(flush, 0);
+        },
+        clearNext(timer) {
+          customClearTimeoutWasUsed = true;
+          return clearTimeout(timer);
+        },
+        now() {
+          return Date.now();
+        }
+      };
     }
   });
 
@@ -111,23 +122,33 @@ QUnit.test('We can use a custom clearTimeout', function(assert) {
 });
 
 QUnit.test('We can use a custom now', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
   let done = assert.async();
 
   let currentTime = 10;
   let customNowWasUsed = false;
   let bb = new Backburner(['one'], {
-    _platform: {
-      now() {
-        customNowWasUsed = true;
-        return currentTime += 10;
-      },
-      isFakePlatform: true
+    _buildPlatform(flush) {
+      return {
+        setTimeout(method, wait) {
+          return setTimeout(method, wait);
+        },
+        clearTimeout(id) {
+          clearTimeout(id);
+        },
+        next() {
+          return setTimeout(flush, 0);
+        },
+        clearNext() { },
+        now() {
+          customNowWasUsed = true;
+          return currentTime += 10;
+        },
+      };
     }
   });
 
   bb.later(() => {
-    assert.ok(bb.options._platform.isFakePlatform, 'we are using the fake platform');
     assert.ok(customNowWasUsed , 'custom now was used');
     done();
   }, 10);

--- a/tests/debounce-test.ts
+++ b/tests/debounce-test.ts
@@ -23,21 +23,21 @@ QUnit.test('debounce', function(assert) {
   // let's schedule `debouncee` to run in 10ms
   setTimeout(() => {
     assert.equal(step++, 1);
-    assert.ok(!wasCalled);
+    assert.ok(!wasCalled, '@10ms, should not yet have been called');
     bb.debounce(null, debouncee, 40);
   }, 10);
 
   // let's schedule `debouncee` to run again in 30ms
   setTimeout(() => {
     assert.equal(step++, 2);
-    assert.ok(!wasCalled);
+    assert.ok(!wasCalled, '@ 30ms, should not yet have been called');
     bb.debounce(null, debouncee, 40);
   }, 30);
 
   // let's schedule `debouncee` to run yet again in 60ms
   setTimeout(() => {
     assert.equal(step++, 3);
-    assert.ok(!wasCalled);
+    assert.ok(!wasCalled, '@ 60ms, should not yet have been called');
     bb.debounce(null, debouncee, 40);
   }, 60);
 
@@ -45,7 +45,7 @@ QUnit.test('debounce', function(assert) {
   // 10ms after `debouncee` has been called the last time
   setTimeout(() => {
     assert.equal(step++, 4);
-    assert.ok(wasCalled);
+    assert.ok(wasCalled, '@ 110ms should have been called');
   }, 110);
 
   // great, we've made it this far, there's one more thing

--- a/tests/multi-turn-test.ts
+++ b/tests/multi-turn-test.ts
@@ -1,30 +1,25 @@
-import Backburner from 'backburner';
+import Backburner, { buildPlatform } from 'backburner';
 
 QUnit.module('tests/multi-turn');
 
 const queue: any[] = [];
-const platform = {
-  flushSync() {
-    let current = queue.slice();
-    queue.length = 0;
-    current.forEach((task) => task());
-  },
-
-  // TDB actually implement
-  next(cb) {
-    queue.push(cb);
-  }
-};
+let platform;
+function buildFakePlatform(flush) {
+  platform = buildPlatform(flush);
+  platform.flushSync = function() {
+    flush();
+  };
+  return platform;
+}
 
 QUnit.test('basic', function(assert) {
   let bb = new Backburner(['zomg'], {
-
     // This is just a place holder for now, but somehow the system needs to
     // know to when to stop
     mustYield() {
       return true; // yield after each step, for now.
     },
-    _platform: platform
+    _buildPlatform: buildFakePlatform
   });
 
   let order = -1;
@@ -88,7 +83,7 @@ QUnit.test('properly cancel items which are added during flush', function(assert
       return true; // yield after each step, for now.
     },
 
-    _platform: platform
+    _buildPlatform: buildFakePlatform
   });
 
   let fooCalled = 0;

--- a/tests/queue-test.ts
+++ b/tests/queue-test.ts
@@ -59,7 +59,7 @@ QUnit.test('Queue#flush should be recursive if new items are added', function(as
 
 QUnit.test('Default queue is automatically set to first queue if none is provided', function(assert) {
   let bb = new Backburner(['one', 'two']);
-  assert.equal(bb.options.defaultQueue, 'one');
+  assert.equal(bb.defaultQueue, 'one');
 });
 
 QUnit.test('Default queue can be manually configured', function(assert) {
@@ -67,7 +67,7 @@ QUnit.test('Default queue can be manually configured', function(assert) {
     defaultQueue: 'two'
   });
 
-  assert.equal(bb.options.defaultQueue, 'two');
+  assert.equal(bb.defaultQueue, 'two');
 });
 
 QUnit.test('onBegin and onEnd are called and passed the correct parameters', function(assert) {


### PR DESCRIPTION
* Replace the private `_platform` option, with a new `_buildPlatform`
* Add interfaces for the constructor args for the `Backburner` class.
* Move the main implementation of `Backburner.prototype.end` into a
  private method (`_end`) that is aware of if the end is from an autorun
  or manual run...
* Extract steps to schedule an autorun out into stand alone private
  method (`_scheduleAutorun`)
* Leverage microtask queue (via either `promise.then(...)` or
  `MutationObserver`) to schedule an autorun
* Leverage microtask queue to advance from one queue to the next

This PR is just a small stepping stone towards leveraging microtasks a bit more (with the goal of removing Ember's autorun assertion)...