### PR TITLE
Add benchmark for "normal" schedule and flush.

### DIFF
--- a/bench/benches/schedule-flush.js
+++ b/bench/benches/schedule-flush.js
@@ -1,0 +1,87 @@
+var Backburner = require('../../dist/backburner');
+
+function prodSetup() {
+  var backburner = new this.Backburner(["sync", "actions", "routerTransitions", "render", "afterRender", "destroy", "rsvpAfter"]);
+
+  var target = {
+    someMethod: function() { }
+  };
+}
+
+function debugSetup() {
+  var backburner = new this.Backburner(["sync", "actions", "routerTransitions", "render", "afterRender", "destroy", "rsvpAfter"]);
+  backburner.DEBUG = true;
+
+  var target = {
+    someMethod: function() { }
+  };
+}
+
+let scenarios = [];
+
+let base = [{
+  name: 'Schedule & Flush - function',
+
+  Backburner: Backburner,
+
+  fn: function() {
+    backburner.begin();
+    backburner.schedule('render', function() {});
+    backburner.end();
+  }
+}, {
+  name: 'Schedule & Flush - target, function',
+
+  Backburner: Backburner,
+
+  fn: function() {
+    backburner.begin();
+    backburner.schedule('render', target, function() {});
+    backburner.end();
+  }
+}, {
+  name: 'Schedule & Flush - target, string method name',
+
+  Backburner: Backburner,
+
+  fn: function() {
+    backburner.begin();
+    backburner.schedule('render', target, 'someMethod');
+    backburner.end();
+  }
+}, {
+  name: 'Schedule & Flush - target, string method name, 1 argument',
+
+  Backburner: Backburner,
+
+  fn: function() {
+    backburner.begin();
+    backburner.schedule('render', target, 'someMethod', 'foo');
+    backburner.end();
+  }
+}, {
+  name: 'Schedule & Flush - target, string method name, 2 arguments',
+
+  Backburner: Backburner,
+
+  fn: function() {
+    backburner.begin();
+    backburner.schedule('render', target, 'someMethod', 'foo', 'bar');
+    backburner.end();
+  }
+}];
+
+base.forEach(item => {
+  let prodItem = Object.assign({}, item);
+  prodItem.setup = prodSetup;
+  scenarios.push(prodItem);
+});
+
+base.forEach(item => {
+  let debugItem = Object.assign({}, item);
+  debugItem.name = `DEBUG - ${debugItem.name}`;
+  debugItem.setup = debugSetup;
+  scenarios.push(debugItem);
+});
+
+module.exports = scenarios;

--- a/bench/index.js
+++ b/bench/index.js
@@ -2,8 +2,21 @@ var glob = require('glob');
 var path = require('path');
 var bench = require('do-you-even-bench');
 
+// to run all (default):
+//
+// node ./bench/index.js
+//
+// to run a single benchmark, you can do:
+//
+// node ./bench/index.js ./bench/benches/some-file.js
+var fileGlob = './bench/benches/*.js';
+if (process.argv[2]) {
+  fileGlob = process.argv[2];
+  console.log(fileGlob);
+}
+
 var suites = [];
-glob.sync('./bench/benches/*.js').forEach(function(file) {
+glob.sync(fileGlob).forEach(function(file) {
   var exported = require( path.resolve( file ) );
   if (Array.isArray(exported)) {
     suites = suites.concat(exported);


### PR DESCRIPTION
Add benchmark for "normal" schedule and flush.  Also tests DEBUG vs non-DEBUG versions (to get an idea of the performance trade-offs).

Output at the moment:

``` testing
- Schedule & Flush - function
- Schedule & Flush - target, function
- Schedule & Flush - target, string method name
- Schedule & Flush - target, string method name, 1 argument
- Schedule & Flush - target, string method name, 2 arguments
- DEBUG - Schedule & Flush - function
- DEBUG - Schedule & Flush - target, function
- DEBUG - Schedule & Flush - target, string method name
- DEBUG - Schedule & Flush - target, string method name, 1 argument
- DEBUG - Schedule & Flush - target, string method name, 2 arguments
running first test, please wait...
 Schedule & Flush - function .............................................
561,518.02 op/s
 Schedule & Flush - target, function .....................................
489,466.23 op/s
 Schedule & Flush - target, string method name ...........................
439,886.83 op/s
 Schedule & Flush - target, string method name, 1 argument ...............
463,977.73 op/s
 Schedule & Flush - target, string method name, 2 arguments ..............
487,001.40 op/s
 DEBUG - Schedule & Flush - function .....................................
119,106.06 op/s
 DEBUG - Schedule & Flush - target, function .............................
119,205.05 op/s
 DEBUG - Schedule & Flush - target, string method name ...................
120,961.27 op/s
 DEBUG - Schedule & Flush - target, string method name, 1 argument .......
113,748.35 op/s
 DEBUG - Schedule & Flush - target, string method name, 2 arguments ......
113,232.08 op/s fastest: Schedule & Flush - function
```