### PR TITLE
use consistent argument parser

### DIFF
--- a/tests/debounce-test.ts
+++ b/tests/debounce-test.ts
@@ -560,3 +560,19 @@ QUnit.test('debounce within a debounce can be canceled GH#183', function(assert)
 
   foo();
 });
+
+QUnit.test('when [callback, string] args passed', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['one']);
+  let functionWasCalled = false;
+
+  bb.run(() => {
+    bb.debounce(function(name) {
+      assert.equal(name, 'batman');
+      functionWasCalled = true;
+    }, 'batman', 100, true);
+  });
+
+  assert.ok(functionWasCalled, 'function was called');
+});

--- a/tests/defer-once-test.ts
+++ b/tests/defer-once-test.ts
@@ -316,3 +316,19 @@ QUnit.test('onError', function(assert) {
     });
   });
 });
+
+QUnit.test('when [queueName, callback, string] args passed', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['one']);
+  let functionWasCalled = false;
+
+  bb.run(() => {
+    bb.scheduleOnce('one', function(name) {
+      assert.equal(name, 'batman');
+      functionWasCalled = true;
+    }, 'batman', 100);
+  });
+
+  assert.ok(functionWasCalled, 'function was called');
+});

--- a/tests/defer-test.ts
+++ b/tests/defer-test.ts
@@ -36,6 +36,22 @@ QUnit.test('when passed a target and method', function(assert) {
   assert.ok(functionWasCalled, 'function was called');
 });
 
+QUnit.test('when [queueName, callback, string] args passed', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['one']);
+  let functionWasCalled = false;
+
+  bb.run(() => {
+    bb.schedule('one', function(name) {
+      assert.equal(name, 'batman');
+      functionWasCalled = true;
+    }, 'batman');
+  });
+
+  assert.ok(functionWasCalled, 'function was called');
+});
+
 QUnit.test('when passed a target and method name', function(assert) {
   assert.expect(2);
 

--- a/tests/join-test.ts
+++ b/tests/join-test.ts
@@ -199,3 +199,17 @@ QUnit.test('onError which does rethrow is invoked (only once) when joining an ex
     });
   }, /test error/);
 });
+
+QUnit.test('when [callback, string] args passed', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['one']);
+  let functionWasCalled = false;
+
+  bb.join(function(name) {
+    assert.equal(name, 'batman');
+    functionWasCalled = true;
+  }, 'batman');
+
+  assert.ok(functionWasCalled, 'function was called');
+});

--- a/tests/run-test.ts
+++ b/tests/run-test.ts
@@ -175,3 +175,17 @@ QUnit.test('onError with target and action', function(assert) {
 
   bb.run(() => { throw new Error('QUnit.test error'); });
 });
+
+QUnit.test('when [callback, string] args passed', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['one']);
+  let functionWasCalled = false;
+
+  bb.run(function(name) {
+    assert.equal(name, 'batman');
+    functionWasCalled = true;
+  }, 'batman');
+
+  assert.ok(functionWasCalled, 'function was called');
+});

--- a/tests/set-timeout-test.ts
+++ b/tests/set-timeout-test.ts
@@ -362,3 +362,15 @@ QUnit.test('NaN timeout doesn\'t hang other timeouts', function(assert) {
     done();
   }, 20);
 });
+
+QUnit.test('when [callback, string] args passed', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  let bb = new Backburner(['one']);
+
+  bb.later(function(name) {
+    assert.equal(name, 'batman');
+    done();
+  }, 'batman', 0);
+});

--- a/tests/throttle-test.ts
+++ b/tests/throttle-test.ts
@@ -509,3 +509,19 @@ QUnit.test('throttle + immediate joins existing run loop instances', function(as
     }, 20, true);
   });
 });
+
+QUnit.test('when [callback, string] args passed', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['one']);
+  let functionWasCalled = false;
+
+  bb.run(() => {
+    bb.throttle(function(name) {
+      assert.equal(name, 'batman');
+      functionWasCalled = true;
+    }, 'batman', 200);
+  });
+
+  assert.ok(functionWasCalled, 'function was called');
+});


### PR DESCRIPTION
* aligns argument parsing logic together 
* fixes issue when `schedule/scheduleOnce/run/join` not behaving correctly when `[callback, string]` signature arguments passed 