### PR TITLE
CI: Use `yarn` instead of `npm`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
 
 cache: yarn
 
+install:
+  - yarn --no-lockfile
+
 script:
   - yarn problems
   - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,12 @@ env:
     - secure: cAsSmFA77dBTgo7JHT3kcXlwAfilDoOwrVo3b77SHj64rWVUjB3xyaCWY+3gCoULTDD/fuEO80TWwzfV2sQGASvJyrSNLw3P7//Ym/dkHcTdQ3CfCagCf689/PfFTMM1+v6gZHSYcryJzRWkLolEgFlkU+lw4rwVlRjrKSwnRgQ=
     - secure: bNBRMlxWFRbAR04OI1SfwfYJis9KTm0C6O/xkAuMiardqJ6z+EpTXKSplAu6MlUM5VsiOON2ZNwo3bwmtshWhGiUhOVnjZCBtuVcJXyj/RQk9ug8A8pFKYn4o3Yn57H6o4tj/Gw3/NV5ocbw5MzRbgCSFkLbHl9lPDRTYyX2SwM=
 
-cache:
-  directories:
-    - node_modules
+cache: yarn
 
 script:
-  - npm run problems
-  - npm run lint
-  - npm test
+  - yarn problems
+  - yarn lint
+  - yarn test
 
 after_success:
-  - npm build
-
+  - yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
 
 cache: yarn
 
+before_install:
+  # use most recent stable `yarn` version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 install:
   - yarn --no-lockfile
 


### PR DESCRIPTION
This PR switches TravisCI over to explicitly use `yarn` instead of `npm`.