### PR TITLE
vscode: Remove `editor.renderWhitespace` setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
     "tmp": true,
     "config": true
   },
-  "editor.renderWhitespace": "boundary",
   "editor.insertSpaces": true,
   "editor.tabSize": 2
 }


### PR DESCRIPTION
This setting is based on personal opinion and should be in the user config, not the shared workspace config