### PR TITLE
Failing test case for GH#332.

### DIFF
--- a/lib/backburner/deferred-action-queues.ts
+++ b/lib/backburner/deferred-action-queues.ts
@@ -59,7 +59,7 @@ export default class DeferredActionQueues {
 
       if (queue.hasWork() === false) {
         this.queueNameIndex++;
-        if (fromAutorun) {
+        if (fromAutorun && this.queueNameIndex < numberOfQueues) {
           return QUEUE_STATE.Pause;
         }
       } else {


### PR DESCRIPTION
Before the fixing commit, the CI build fails with:

```
not ok 5 Chrome 62.0 - tests/autorun: autorun interleaved with microtasks do not get dropped [GH#332]
    ---
        actual: >
            first,second,third
        expected: >
            first,second,third,fourth
        stack: >
                at http://localhost:7357/2539/named-amd/tests.js:98:16
        Log: |
    ...
```

After the fix is 🍏 

Fixes #335