### PR TITLE
[Proposal] Async stack traces.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -770,12 +770,14 @@ export default class Backburner {
     let resolve;
 
     new Promise((_resolve) => resolve = _resolve)
-    .then(method.bind(target, ...args))
+    .then(() => method.apply(target, args))
     .catch((err) => {
       let onError = getOnError(this.options);
 
       if (onError) {
         onError.call(null, err, stackError);
+      } else {
+        throw err;
       }
     });
 

--- a/tests/debug-test.ts
+++ b/tests/debug-test.ts
@@ -18,12 +18,14 @@ QUnit.test('schedule - DEBUG flag enables stack tagging', function(assert) {
 
   if (new Error().stack) { // workaround for CLI runner :(
     assert.expect(4);
+    let done = assert.async();
     let stack = bb.currentInstance && bb.currentInstance.queues.one.stackFor(1);
     assert.ok(typeof stack === 'string', 'A stack is recorded');
 
     let onError = function(error, errorRecordedForStack) {
       assert.ok(errorRecordedForStack, 'errorRecordedForStack passed to error function');
       assert.ok(errorRecordedForStack.stack, 'stack is recorded');
+      done();
     };
 
     bb = new Backburner(['errors'], { onError });


### PR DESCRIPTION
This PR introduces async stack traces to Backburner so it's easier to debug the runloop by allowing the developer to step back through the asynchronous stack frame.

Before / After Stack Trace for this [demo code](https://github.com/adriancooney/backburner.js/blob/adrian.cooney/async-stack-traces-demo/demo/index.ts)

![before-after-backburner-stack-trace](https://user-images.githubusercontent.com/621110/38362449-c8958d74-38c8-11e8-8faa-bc4799a7d80d.png)

*[gif of stepping though demo call stack](https://i.imgur.com/fx9WSD5.gif)*

After some cursory research, it doesn't look like there's an API for custom async stack traces available in Chrome. It was actually [requested](https://bugs.chromium.org/p/chromium/issues/detail?id=332624) from what looks like an Ember developer however that was back in 2014 and there hasn't been much activity on it since. This only left the hacky approach of emulating what Chrome thinks is an async action via Promises. I've created a new method on the `Backburner` class called `_asyncExecute` that takes a method and returns a new Promise's `resolve` method (not the promise itself!) synchronously. When that returned `resolve` method is called by Backburner (as if it was the `method` itself), the promise chain advances and calls the original method passed to `_asyncExecute`. This tricks the Dev Tools into thinking some asynchronous action happened when in fact it's just a simple callback.

Thankfully we only need to patch two methods, `schedule` and `later`. `later` doesn't *entirely* need to be patched because Chrome can accurately represent it's async operation as it's a `setTimeout` however it also gets `schedule`d into the default queue for execution once the timeout completes which is *two* async hops. With patching `later`, we reduce this to one async hop for clarity. All of this of course only happens when `Backburner#DEBUG` is true. Finally, there is no breaking API changes.

The method is a little hacky and the `Promise.then (async)` in between async stack frames in the sidebar Call Stack (see gif) is a little misleading but I'd consider this a minor setback for an increase to debuggability and productivity. One of my biggest gripes with Ember is how frustrating it is to debug the runloop.

I expected a performance hit to Backburner in debug mode because of the promises ontop of the current stack stitching system but to my surprise, there's barely any. I suspect it's the `new Error` call that is causing such a performance hit between non-debug and debug modes. When [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1142571) and Safari (and Edge?) supports async stack traces, maybe we could remove that call altogether and get `DEBUG` performance to a [reasonable level](https://guides.emberjs.com/v2.13.0/configuring-ember/debugging/#toc_errors-within-code-ember-run-later-code-a-href-https-github-com-ebryn-backburner-js-backburner-js-a)?

```
  Benchmark                                                                            |     master      |      PR
  ------------------------------------------------------------------------------------------------------------------------
  DEBUG - Schedule & Flush - function ................................................ | 126,951.07 op/s | 112,396.69 op/s
  DEBUG - Schedule & Flush - target, function ........................................ | 126,113.43 op/s | 118,414.02 op/s
  DEBUG - Schedule & Flush - target, string method name .............................. | 130,435.87 op/s | 125,710.38 op/s
  DEBUG - Schedule & Flush - target, string method name, 1 argument .................. | 133,912.92 op/s | 128,377.54 op/s
  DEBUG - Schedule & Flush - target, string method name, 2 arguments ................. | 132,708.16 op/s | 129,048.85 op/s
```

<details><summary>`node bench` on master</summary>
<p>

```python
[backburner.js] (master) $ node bench
testing
- Debounce - function
- Debounce & Cancel - function, target
- Later & Cancel - function
- Later & Cancel - function, target
- Schedule & Cancel - function
- Schedule & Cancel - target, function
- Schedule & Cancel - target, string method name
- Schedule & Cancel - target, string method name, 1 argument
- Schedule & Cancel - target, string method name, 2 arguments
- Schedule & Cancel - prescheduled, same queue - target, string method name
- Schedule & Cancel - prescheduled, separate queue - target, string method name
- Schedule & Flush - function
- Schedule & Flush - target, function
- Schedule & Flush - target, string method name
- Schedule & Flush - target, string method name, 1 argument
- Schedule & Flush - target, string method name, 2 arguments
- DEBUG - Schedule & Flush - function
- DEBUG - Schedule & Flush - target, function
- DEBUG - Schedule & Flush - target, string method name
- DEBUG - Schedule & Flush - target, string method name, 1 argument
- DEBUG - Schedule & Flush - target, string method name, 2 arguments
- Throttle - function
- Throttle & Cancel - function, target
running first test, please wait...
  Debounce - function ................................................................ 324,055.10 op/s
  Debounce & Cancel - function, target ............................................... 291,506.86 op/s
  Later & Cancel - function .......................................................... 333,466.75 op/s
  Later & Cancel - function, target .................................................. 330,913.76 op/s
  Schedule & Cancel - function ..................................................... 4,526,880.55 op/s
  Schedule & Cancel - target, function ............................................. 2,215,570.12 op/s
  Schedule & Cancel - target, string method name ................................... 2,166,164.74 op/s
  Schedule & Cancel - target, string method name, 1 argument ....................... 2,008,147.17 op/s
  Schedule & Cancel - target, string method name, 2 arguments ...................... 1,941,816.72 op/s
  Schedule & Cancel - prescheduled, same queue - target, string method name ........ 1,187,647.98 op/s
  Schedule & Cancel - prescheduled, separate queue - target, string method name .... 2,103,827.47 op/s
  Schedule & Flush - function ........................................................ 512,620.24 op/s
  Schedule & Flush - target, function ................................................ 497,121.32 op/s
  Schedule & Flush - target, string method name ...................................... 484,099.56 op/s
  Schedule & Flush - target, string method name, 1 argument .......................... 485,970.45 op/s
  Schedule & Flush - target, string method name, 2 arguments ......................... 480,963.27 op/s
  DEBUG - Schedule & Flush - function ................................................ 126,951.07 op/s
  DEBUG - Schedule & Flush - target, function ........................................ 126,113.43 op/s
  DEBUG - Schedule & Flush - target, string method name .............................. 130,435.87 op/s
  DEBUG - Schedule & Flush - target, string method name, 1 argument .................. 133,912.92 op/s
  DEBUG - Schedule & Flush - target, string method name, 2 arguments ................. 132,708.16 op/s
  Throttle - function .............................................................. 4,038,990.57 op/s
  Throttle & Cancel - function, target ............................................. 1,778,177.93 op/s
fastest: Schedule & Cancel - function
```
</p>
</details>

<details><summary>`node bench` on this PR</summary>
<p>

```python
[backburner.js] (adrian.cooney/async-stack-traces) $ node bench
testing
- Debounce - function
- Debounce & Cancel - function, target
- Later & Cancel - function
- Later & Cancel - function, target
- Schedule & Cancel - function
- Schedule & Cancel - target, function
- Schedule & Cancel - target, string method name
- Schedule & Cancel - target, string method name, 1 argument
- Schedule & Cancel - target, string method name, 2 arguments
- Schedule & Cancel - prescheduled, same queue - target, string method name
- Schedule & Cancel - prescheduled, separate queue - target, string method name
- Schedule & Flush - function
- Schedule & Flush - target, function
- Schedule & Flush - target, string method name
- Schedule & Flush - target, string method name, 1 argument
- Schedule & Flush - target, string method name, 2 arguments
- DEBUG - Schedule & Flush - function
- DEBUG - Schedule & Flush - target, function
- DEBUG - Schedule & Flush - target, string method name
- DEBUG - Schedule & Flush - target, string method name, 1 argument
- DEBUG - Schedule & Flush - target, string method name, 2 arguments
- Throttle - function
- Throttle & Cancel - function, target
running first test, please wait...
  Debounce - function ................................................................ 337,010.46 op/s
  Debounce & Cancel - function, target ............................................... 293,808.65 op/s
  Later & Cancel - function .......................................................... 344,887.98 op/s
  Later & Cancel - function, target .................................................. 328,991.84 op/s
  Schedule & Cancel - function ..................................................... 4,501,900.81 op/s
  Schedule & Cancel - target, function ............................................. 2,206,946.83 op/s
  Schedule & Cancel - target, string method name ................................... 2,129,333.73 op/s
  Schedule & Cancel - target, string method name, 1 argument ....................... 1,800,934.46 op/s
  Schedule & Cancel - target, string method name, 2 arguments ...................... 1,745,172.19 op/s
  Schedule & Cancel - prescheduled, same queue - target, string method name ........ 1,130,978.88 op/s
  Schedule & Cancel - prescheduled, separate queue - target, string method name .... 1,890,185.90 op/s
  Schedule & Flush - function ........................................................ 480,524.04 op/s
  Schedule & Flush - target, function ................................................ 491,834.57 op/s
  Schedule & Flush - target, string method name ...................................... 496,861.43 op/s
  Schedule & Flush - target, string method name, 1 argument .......................... 482,918.45 op/s
  Schedule & Flush - target, string method name, 2 arguments ......................... 476,500.03 op/s
  DEBUG - Schedule & Flush - function ................................................ 112,396.69 op/s
  DEBUG - Schedule & Flush - target, function ........................................ 118,414.02 op/s
  DEBUG - Schedule & Flush - target, string method name .............................. 125,710.38 op/s
  DEBUG - Schedule & Flush - target, string method name, 1 argument .................. 128,377.54 op/s
  DEBUG - Schedule & Flush - target, string method name, 2 arguments ................. 129,048.85 op/s
  Throttle - function .............................................................. 3,968,894.84 op/s
  Throttle & Cancel - function, target ............................................. 1,743,115.59 op/s
fastest: Schedule & Cancel - function
```
</p>
</details>

---

I've stuck up a page on Github that gives you a demo. Be sure to open Dev Tools and stick a breakpoint in `done`.

http://adriancooney.ie/backburner.js/dist/demo/

Todo:
* [ ] Write some extra tests. Suggestions welcome because the effects lie in the Dev Tools.