### PR TITLE
Always reinstall timers

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -654,10 +654,8 @@ export default class Backburner {
       let i = searchTimer(executeAt, this._timers);
       this._timers.splice(i, 0, executeAt, id, target, method, args, stack);
 
-      // we should be the new earliest timer if i == 0
-      if (i === 0) {
-        this._reinstallTimerTimeout();
-      }
+      // always reinstall since it could be out of sync
+      this._reinstallTimerTimeout();
     }
     return id;
   }

--- a/tests/later-test.ts
+++ b/tests/later-test.ts
@@ -74,6 +74,34 @@ QUnit.test('later should rely on stubbed `Date.now`', function(assert) {
   }, 1);
 });
 
+QUnit.test('later shedules timers correctly after time travel', function(assert) {
+  assert.expect(2);
+
+  let bb = new Backburner(['one']);
+  let done = assert.async();
+  let start = originalDateNow();
+  let now = start;
+
+  Date.now = () => now;
+
+  let called1At = 0;
+  let called2At = 0;
+
+  bb.later(() => called1At = originalDateNow(), 1000);
+
+  now += 1000;
+
+  bb.later(() => called2At = originalDateNow(), 10);
+
+  now += 10;
+
+  setTimeout(() => {
+    assert.ok(called1At !== 0, 'timeout 1 was called');
+    assert.ok(called2At !== 0, 'timeout 2 was called');
+    done();
+  }, 20);
+});
+
 let bb;
 QUnit.module('later arguments / arity', {
   beforeEach() {


### PR DESCRIPTION
This patch fixes the issues in #353 & #354. I don't think there is a better way to solve it, that handles all corner cases.

Note that there is still an issue when "time travel" happens, but no new timers are installed. Ideally, browsers would provide an event when this happens, but this is not the case.

The best workaround would probably be to add a hook to the [`visibilitychange`](https://developer.mozilla.org/en-US/docs/Web/Events/visibilitychange) event, and call `_reinstallTimerTimeout()` when `document.visibilityState === 'visible'`. Unfortunately, this is also called on tab switches, and wouldn't trigger for a tab that is already `'hidden'` (until it is made visible).