### PR TITLE
remove redundant codepath

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -500,7 +500,7 @@ export default class Backburner {
         this._join(target, method, args);
       }
     } else {
-      let executeAt = this._platform.now() + wait || this._timers[index];
+      let executeAt = this._platform.now() + wait;
       this._timers[index] = executeAt;
 
       let argIndex = index + 4;


### PR DESCRIPTION
for some reason I assumed that `this._timers[index]` contained `wait` time when I added it, it contains expiration time for older debounce call timer, so it is invalid to use also it never executed even if `wait` is falsy  
