### PR TITLE
Adding autorun stack to debug info

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -236,8 +236,8 @@ export default class Backburner {
       if (this._autorun === null) { return; }
 
       this._autorun = null;
-      this._end(true /* fromAutorun */);
       this._autorunStack = null;
+      this._end(true /* fromAutorun */);
     };
 
     let builder = this.options._buildPlatform || buildPlatform;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -211,6 +211,7 @@ export default class Backburner {
   private _boundRunExpiredTimers: () => void;
 
   private _autorun: number | null = null;
+  private _autorunStack: Error | undefined;
   private _boundAutorunEnd: () => void;
   private _defaultQueue: string;
 
@@ -566,6 +567,7 @@ export default class Backburner {
   public getDebugInfo() {
     if (this.DEBUG) {
       return {
+        autorun: this._autorunStack,
         counters: this.counters,
         timers: getQueueItems(this._timers, TIMERS_OFFSET, 2),
         instanceStack: [this.currentInstance, ...this.instanceStack]
@@ -758,6 +760,7 @@ export default class Backburner {
   private _ensureInstance(): DeferredActionQueues {
     let currentInstance = this.currentInstance;
     if (currentInstance === null) {
+      this._autorunStack = this.DEBUG ? new Error() : undefined;
       currentInstance = this.begin();
       this._scheduleAutorun();
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -211,7 +211,7 @@ export default class Backburner {
   private _boundRunExpiredTimers: () => void;
 
   private _autorun: number | null = null;
-  private _autorunStack: Error | undefined;
+  private _autorunStack: Error | undefined | null = null;
   private _boundAutorunEnd: () => void;
   private _defaultQueue: string;
 
@@ -237,6 +237,7 @@ export default class Backburner {
 
       this._autorun = null;
       this._end(true /* fromAutorun */);
+      this._autorunStack = null;
     };
 
     let builder = this.options._buildPlatform || buildPlatform;
@@ -650,6 +651,7 @@ export default class Backburner {
     if (this._autorun !== null) {
       this._platform.clearNext(this._autorun);
       this._autorun = null;
+      this._autorunStack = null;
     }
   }
 

--- a/tests/debug-info-test.ts
+++ b/tests/debug-info-test.ts
@@ -5,10 +5,6 @@ import MockStableError, {
   resetError,
 } from './utils/mock-stable-error';
 
-function getDebugInfo(bb) {
-  return bb.currentInstance && bb.getDebugInfo();
-}
-
 QUnit.module('tests/debug-info', {
   beforeEach: function() {
     // @ts-ignore
@@ -27,7 +23,7 @@ QUnit.test('getDebugInfo returns undefined when DEBUG = false', function(assert)
   let bb = new Backburner(['one']);
 
   bb.run(function() {
-    debugInfo = getDebugInfo(bb);
+    debugInfo = bb.getDebugInfo();
 
     assert.equal(debugInfo, undefined, 'DebugInfo is undefined when DEBUG = false');
   });
@@ -52,7 +48,7 @@ QUnit.test('getDebugInfo returns debugInfo using later when DEBUG = true', funct
     bb.later(target1, method, arg1, 1000);
     bb.later(target2, method, arg1, arg2, 1000);
 
-    debugInfo = getDebugInfo(bb);
+    debugInfo = bb.getDebugInfo();
 
     resetError();
 
@@ -94,7 +90,7 @@ QUnit.test('getDebugInfo returns debugInfo using throttle when DEBUG = true', fu
     bb.throttle(target1, method, arg1, 1000, false);
     bb.throttle(target2, method, arg1, arg2, 1000, false);
 
-    debugInfo = getDebugInfo(bb);
+    debugInfo = bb.getDebugInfo();
 
     resetError();
 
@@ -136,7 +132,7 @@ QUnit.test('getDebugInfo returns debugInfo using debounce when DEBUG = true', fu
     bb.debounce(target1, method, arg1, 1000);
     bb.debounce(target2, method, arg1, arg2, 1000);
 
-    debugInfo = getDebugInfo(bb);
+    debugInfo = bb.getDebugInfo();
 
     resetError();
 
@@ -178,7 +174,7 @@ QUnit.test('getDebugInfo returns debugInfo using when DEBUG = true', function(as
     bb.schedule('one', target1, method, arg1);
     bb.schedule('two', target2, method, arg1, arg2);
 
-    debugInfo = getDebugInfo(bb);
+    debugInfo = bb.getDebugInfo();
 
     resetError();
 
@@ -228,7 +224,7 @@ QUnit.test('getDebugInfo returns debugInfo when DEBUG = true in nested run', fun
       bb.schedule('three', method);
       bb.schedule('four', method);
 
-      debugInfo = getDebugInfo(bb);
+      debugInfo = bb.getDebugInfo();
 
       resetError();
 
@@ -284,16 +280,18 @@ QUnit.test('autorun', function(assert) {
   let done = assert.async();
   let bb = new Backburner(['one']);
   let autorunStack = pushStackTrace('Autorun stack');
+  pushStackTrace('Schedule stack');
 
   bb.DEBUG = true;
 
-  assert.equal(getDebugInfo(bb), undefined);
-
   bb.schedule('one', null, () => {
-    assert.equal(getDebugInfo(bb).autorun.stack, autorunStack);
     setTimeout(() => {
-      assert.equal(getDebugInfo(bb), undefined);
+      let debugInfo = bb.getDebugInfo();
+      assert.equal(debugInfo!.autorun, null);
       done();
     });
   });
+
+  let debugInfo = bb.getDebugInfo();
+  assert.equal(debugInfo!.autorun!.stack, autorunStack);
 });

--- a/tests/debug-info-test.ts
+++ b/tests/debug-info-test.ts
@@ -5,6 +5,10 @@ import MockStableError, {
   resetError,
 } from './utils/mock-stable-error';
 
+function getDebugInfo(bb) {
+  return bb.currentInstance && bb.getDebugInfo();
+}
+
 QUnit.module('tests/debug-info', {
   beforeEach: function() {
     // @ts-ignore
@@ -23,7 +27,7 @@ QUnit.test('getDebugInfo returns undefined when DEBUG = false', function(assert)
   let bb = new Backburner(['one']);
 
   bb.run(function() {
-    debugInfo = bb.currentInstance && bb.getDebugInfo();
+    debugInfo = getDebugInfo(bb);
 
     assert.equal(debugInfo, undefined, 'DebugInfo is undefined when DEBUG = false');
   });
@@ -48,7 +52,7 @@ QUnit.test('getDebugInfo returns debugInfo using later when DEBUG = true', funct
     bb.later(target1, method, arg1, 1000);
     bb.later(target2, method, arg1, arg2, 1000);
 
-    debugInfo = bb.currentInstance && bb.getDebugInfo();
+    debugInfo = getDebugInfo(bb);
 
     resetError();
 
@@ -90,7 +94,7 @@ QUnit.test('getDebugInfo returns debugInfo using throttle when DEBUG = true', fu
     bb.throttle(target1, method, arg1, 1000, false);
     bb.throttle(target2, method, arg1, arg2, 1000, false);
 
-    debugInfo = bb.currentInstance && bb.getDebugInfo();
+    debugInfo = getDebugInfo(bb);
 
     resetError();
 
@@ -132,7 +136,7 @@ QUnit.test('getDebugInfo returns debugInfo using debounce when DEBUG = true', fu
     bb.debounce(target1, method, arg1, 1000);
     bb.debounce(target2, method, arg1, arg2, 1000);
 
-    debugInfo = bb.currentInstance && bb.getDebugInfo();
+    debugInfo = getDebugInfo(bb);
 
     resetError();
 
@@ -174,7 +178,7 @@ QUnit.test('getDebugInfo returns debugInfo using when DEBUG = true', function(as
     bb.schedule('one', target1, method, arg1);
     bb.schedule('two', target2, method, arg1, arg2);
 
-    debugInfo = bb.currentInstance && bb.getDebugInfo();
+    debugInfo = getDebugInfo(bb);
 
     resetError();
 
@@ -224,7 +228,7 @@ QUnit.test('getDebugInfo returns debugInfo when DEBUG = true in nested run', fun
       bb.schedule('three', method);
       bb.schedule('four', method);
 
-      debugInfo = bb.currentInstance && bb.getDebugInfo();
+      debugInfo = getDebugInfo(bb);
 
       resetError();
 
@@ -274,4 +278,22 @@ QUnit.test('getDebugInfo returns debugInfo when DEBUG = true in nested run', fun
       , 'debugInfo is output');
       });
     });
+});
+
+QUnit.test('autorun', function(assert) {
+  let done = assert.async();
+  let bb = new Backburner(['one']);
+  let autorunStack = pushStackTrace('Autorun stack');
+
+  bb.DEBUG = true;
+
+  assert.equal(getDebugInfo(bb), undefined);
+
+  bb.schedule('one', null, () => {
+    assert.equal(getDebugInfo(bb).autorun.stack, autorunStack);
+    setTimeout(() => {
+      assert.equal(getDebugInfo(bb), undefined);
+      done();
+    });
+  });
 });

--- a/tests/debug-info-test.ts
+++ b/tests/debug-info-test.ts
@@ -286,12 +286,10 @@ QUnit.test('autorun', function(assert) {
 
   bb.schedule('one', null, () => {
     setTimeout(() => {
-      let debugInfo = bb.getDebugInfo();
-      assert.equal(debugInfo!.autorun, null);
+      assert.equal(bb.getDebugInfo()!.autorun, null);
       done();
     });
   });
 
-  let debugInfo = bb.getDebugInfo();
-  assert.equal(debugInfo!.autorun!.stack, autorunStack);
+  assert.equal(bb.getDebugInfo()!.autorun!.stack, autorunStack);
 });


### PR DESCRIPTION
Adding autorun stack to `getDebugInfo` in order to better determine the source that triggered an autorun.