### PR TITLE
Use Promise microtask queue as first option.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ export {
 } from './backburner/platform';
 
 import {
+  buildNext,
   buildPlatform,
   IPlatform,
 } from './backburner/platform';
@@ -153,6 +154,8 @@ export interface IBackburnerOptions {
 
 export default class Backburner {
   public static Queue = Queue;
+  public static buildPlatform = buildPlatform;
+  public static buildNext = buildNext;
 
   public DEBUG = false;
 

--- a/tests/build-next-test.ts
+++ b/tests/build-next-test.ts
@@ -1,0 +1,26 @@
+import Backburner from 'backburner';
+
+QUnit.module('tests/build-next', function() {
+
+  QUnit.test('can build custom flushing next', function(assert) {
+    let done = assert.async();
+    let next = Backburner.buildNext(() => assert.step('custom next'));
+
+    assert.step('start');
+    Promise.resolve().then(() => assert.step('first promise resolved'));
+    next();
+    Promise.resolve().then(() => assert.step('second promise resolved'));
+    assert.step('end');
+
+    setTimeout(() => {
+      assert.verifySteps([
+        'start',
+        'end',
+        'first promise resolved',
+        'custom next',
+        'second promise resolved',
+      ]);
+      done();
+    }, 10);
+  });
+});

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,6 @@
 import './autorun-test';
 import './bb-has-timers-test';
+import './build-next-test';
 import './cancel-test';
 import './configurable-timeout-test';
 import './debounce-test';


### PR DESCRIPTION
This change swaps the order so that Backburner will use Promises _first_ then fallback to `MutationObserver` if `Promise` is not present (**cough** IE11 **cough**).

This makes debugging a bit nicer since it shows `"Promise.then (async)"` instead of `"character data (async)"`), and also ensures that we can more consistently target the right microtask queue.

---

This is the result of a longer debugging session where @stefanpenner (and I) determined that there is a difference between Safari and Chrome in how mutation observer microtasks and promise microtasks are queued.