### PR TITLE
Enable flush timing to be controlled from the host.

### DIFF
--- a/lib/backburner/deferred-action-queues.ts
+++ b/lib/backburner/deferred-action-queues.ts
@@ -7,9 +7,9 @@ export interface IDebugInfo {
 
 export default class DeferredActionQueues {
   public queues: { [name: string]: Queue } = {};
+  public queueNameIndex = 0;
 
   private queueNames: string[];
-  private queueNameIndex = 0;
 
   constructor(queueNames: string[] = [], options: any) {
     this.queueNames = queueNames;

--- a/lib/backburner/platform.ts
+++ b/lib/backburner/platform.ts
@@ -2,7 +2,7 @@ export interface IPlatform {
   setTimeout(fn: Function, ms: number): any;
   clearTimeout(id: any): void;
   next(): any;
-  clearNext(timerId: any): void;
+  clearNext(): void;
   now(): number;
 }
 

--- a/tests/configurable-timeout-test.ts
+++ b/tests/configurable-timeout-test.ts
@@ -99,9 +99,8 @@ QUnit.test('We can use a custom clearTimeout', function(assert) {
         next() {
           return setTimeout(flush, 0);
         },
-        clearNext(timer) {
+        clearNext() {
           customClearTimeoutWasUsed = true;
-          return clearTimeout(timer);
         },
         now() {
           return Date.now();


### PR DESCRIPTION
* Changes `_autorun` into a boolean
* Adds a new `flush` option to the backburner options which allows the host to either immediately flush (which would equal the prior behavior) via microtasks, **OR** flush "sometime later"
* Adds tests to ensure execution order

Paired with @krisselden 