### PR TITLE
fix issue with debounce smaller wait time replacing other timers

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -521,8 +521,13 @@ export default class Backburner {
         _timers[argIndex] = args;
       } else {
         let stack = this._timers[index + 5];
-        this._timers.splice(i, 0, executeAt, timerId, target, method, args, stack);
-        this._timers.splice(index, TIMERS_OFFSET);
+        if (i < index) {
+          this._timers.splice(index, TIMERS_OFFSET);
+          this._timers.splice(i, 0, executeAt, timerId, target, method, args, stack);
+        } else {
+          this._timers.splice(i, 0, executeAt, timerId, target, method, args, stack);
+          this._timers.splice(index, TIMERS_OFFSET);
+        }
       }
 
       if (index === 0) {

--- a/tests/later-test.ts
+++ b/tests/later-test.ts
@@ -56,6 +56,30 @@ QUnit.test('later', function(assert) {
   }, 20);
 });
 
+QUnit.test('debounce with later', function(assert) {
+  assert.expect(3);
+  let done = assert.async(2);
+  let bb = new Backburner(['batman']);
+
+  function debounceFunc(obj) {
+    assert.notOk(obj.isFoo, 'debounce called with foo');
+    assert.ok(obj.isBar, 'debounce called with bar');
+    done();
+  }
+
+  function laterFunc() {
+    assert.ok(true, 'later called');
+    done();
+  }
+
+  const foo = { isFoo: true };
+  const bar = { isBar: true };
+
+  bb.debounce(debounceFunc, foo, 500);
+  bb.later(laterFunc, 100);
+  bb.debounce(debounceFunc, bar, 10);
+});
+
 QUnit.test('later should rely on stubbed `Date.now`', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
fixes #365 
when new debounce timer is earlier than previous debounce timer: first removing previous then inserting new
when new debounce timer is later than previous debounce timer: first inserting new then removing previous 
so that removing/adding indexes are not shifted 