### PR TITLE
Ensure `scheduleOnce` works correctly following a cancelled job

### DIFF
--- a/lib/backburner/queue.ts
+++ b/lib/backburner/queue.ts
@@ -121,7 +121,7 @@ export default class Queue {
     let index = findItem(target, method, queue);
 
     if (index > -1) {
-      queue.splice(index, QUEUE_ITEM_LENGTH);
+      queue[index + 1] = null;
       return true;
     }
 

--- a/tests/cancel-test.ts
+++ b/tests/cancel-test.ts
@@ -30,18 +30,18 @@ QUnit.test('cancelling does not affect future scheduleOnce calls', function(asse
   const f3 = (arg: string) => f3Calls.push(arg);
 
   bb.run(() => {
-    const toCancel = bb.scheduleOnce('queueName', null, f1, "f1 cancelled schedule");
-    bb.scheduleOnce('queueName', null, f2, "f2 first schedule");
-    bb.scheduleOnce('queueName', null, f3, "f3 first schedule");
+    const toCancel = bb.scheduleOnce('queueName', null, f1, 'f1 cancelled schedule');
+    bb.scheduleOnce('queueName', null, f2, 'f2 first schedule');
+    bb.scheduleOnce('queueName', null, f3, 'f3 first schedule');
     bb.cancel(toCancel);
-    bb.scheduleOnce('queueName', null, f2, "f2 second schedule");
+    bb.scheduleOnce('queueName', null, f2, 'f2 second schedule');
   });
 
-  assert.equal(f1Calls.length, 0, "f1 was not called")
-  assert.equal(f2Calls.length, 1, "f2 was called once")
-  assert.equal(f3Calls.length, 1, "f3 was called once")
-  assert.deepEqual(f2Calls, ["f2 second schedule"], "f2 received the correct argument")
-  assert.deepEqual(f3Calls, ["f3 first schedule"], "f3 received the correct argument")
+  assert.equal(f1Calls.length, 0, 'f1 was not called')
+  assert.equal(f2Calls.length, 1, 'f2 was called once')
+  assert.equal(f3Calls.length, 1, 'f3 was called once')
+  assert.deepEqual(f2Calls, ['f2 second schedule'], 'f2 received the correct argument')
+  assert.deepEqual(f3Calls, ['f3 first schedule'], 'f3 received the correct argument')
 });
 
 QUnit.test('setTimeout', function(assert) {


### PR DESCRIPTION
Previously, cancelling a job would `splice` it from the queue. This was problematic because it affects the index of all later jobs in the queue. The `targetQueues` map of jobs to queue indexes becomes incorrect, leading to arguments being passed to the wrong jobs. For example, given the sequence:

```javascript
const toCancel = bb.scheduleOnce('queueName', null, f1, "f1 cancelled schedule");
bb.scheduleOnce('queueName', null, f2, "f2 first schedule");
bb.scheduleOnce('queueName', null, f3, "f3 first schedule");
bb.cancel(toCancel);
bb.scheduleOnce('queueName', null, f2, "f2 second schedule");
```

The correct behaviour is for `f2` to be called with the argument `"f2 second schedule"`, and f3 to be called with `"f3 first schedule"`.

In reality, `f2` was being called with the the argument from its first schedule ("f2 first schedule") and f3 was being called with the argument from f2's second schedule ("f2 second schedule").

One possible fix would be to iterate over all `targetQueues` and decrement them by `QUEUE_ITEM_LENGTH` if they are greater than the cancelled job's index. That would be `O(n)` where `n` is the number of queued jobs. Instead, this commit nulls out out 'method' of the cancelled job in the queue, thereby making it a no-op (`O(1)`). That is the same technique employed a few lines below when cancelling the job in `_queueBeingFlushed`.